### PR TITLE
Simplify editor launching by removing terminal detection logic

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -204,8 +204,15 @@ func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
 	// Parse the editor env var the way shells treat $EDITOR: the first
 	// token is the binary, the rest are leading arguments (e.g.
 	// `code --wait`, `subl -w`, `nvim -R`). Without this split, exec
-	// looks for a literal binary named `"code --wait"` and 500s.
+	// looks for a literal binary named `"code --wait"` and 500s. A
+	// whitespace-only value slips past the `== ""` guard above but
+	// yields zero fields, so recheck after Fields to avoid indexing a
+	// nil slice and panicking the handler.
 	fields := strings.Fields(s.editor)
+	if len(fields) == 0 {
+		http.Error(w, "no editor configured (set NOTESVIEW_EDITOR, VISUAL, or EDITOR)", http.StatusBadRequest)
+		return
+	}
 	editorBin, editorArgs := fields[0], fields[1:]
 	args := append(append([]string{}, editorArgs...), absPath)
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -196,13 +196,20 @@ func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	editor := s.editor
-	if editor == "" {
+	if s.editor == "" {
 		http.Error(w, "no editor configured (set NOTESVIEW_EDITOR, VISUAL, or EDITOR)", http.StatusBadRequest)
 		return
 	}
 
-	if err := openEditor(editor, absPath); err != nil {
+	// Parse the editor env var the way shells treat $EDITOR: the first
+	// token is the binary, the rest are leading arguments (e.g.
+	// `code --wait`, `subl -w`, `nvim -R`). Without this split, exec
+	// looks for a literal binary named `"code --wait"` and 500s.
+	fields := strings.Fields(s.editor)
+	editorBin, editorArgs := fields[0], fields[1:]
+	args := append(append([]string{}, editorArgs...), absPath)
+
+	if err := openEditor(editorBin, args); err != nil {
 		http.Error(w, fmt.Sprintf("failed to start editor: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -212,39 +219,48 @@ func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
 
 // openEditor launches the editor for the given file. GUI editors are spawned
 // directly. Terminal editors are opened in a new terminal window.
-func openEditor(editor, filePath string) error {
-	base := filepath.Base(editor)
-	if terminalEditors[base] {
-		return openInTerminal(editor, filePath)
+func openEditor(editorBin string, args []string) error {
+	if terminalEditors[filepath.Base(editorBin)] {
+		return openInTerminal(editorBin, args)
 	}
-	cmd := exec.Command(editor, filePath)
+	cmd := exec.Command(editorBin, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return cmd.Start()
 }
 
 // openInTerminal opens a terminal editor in a new terminal window.
-func openInTerminal(editor, filePath string) error {
+func openInTerminal(editorBin string, args []string) error {
 	switch runtime.GOOS {
 	case "darwin":
-		return openInTerminalDarwin(editor, filePath)
+		return openInTerminalDarwin(editorBin, args)
 	case "linux":
-		return openInTerminalLinux(editor, filePath)
+		return openInTerminalLinux(editorBin, args)
 	default:
 		// Fallback: try to run directly (will likely fail for TUI editors
 		// but there's no portable way to open a terminal on this OS)
-		cmd := exec.Command(editor, filePath)
+		cmd := exec.Command(editorBin, args...)
 		return cmd.Start()
 	}
 }
 
-func openInTerminalDarwin(editor, filePath string) error {
-	// Try Ghostty first (via open -na), then iTerm2/Terminal.app via AppleScript.
-	if _, err := os.Stat("/Applications/Ghostty.app"); err == nil {
-		cmd := exec.Command("open", "-na", "Ghostty.app", "--args", "-e", editor, filePath)
+func openInTerminalDarwin(editorBin string, args []string) error {
+	// Prefer Ghostty via its bundled binary. Launching via
+	// `open -na Ghostty.app --args …` is unreliable for .app bundles
+	// because AppKit doesn't always forward `--args` to the inner
+	// executable, so we invoke the binary directly when it's present.
+	ghosttyBin := "/Applications/Ghostty.app/Contents/MacOS/ghostty"
+	if _, err := os.Stat(ghosttyBin); err == nil {
+		ghosttyArgs := append([]string{"-e", editorBin}, args...)
+		cmd := exec.Command(ghosttyBin, ghosttyArgs...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		return cmd.Start()
 	}
 
-	// Fall back to AppleScript: prefer iTerm2 if running, else Terminal.app
+	// Fall back to AppleScript: prefer iTerm2 if running, else Terminal.app.
+	// Both execute a single shell command string, so we POSIX-quote every
+	// argument and concatenate.
+	shellCmd := shellJoin(append([]string{editorBin}, args...))
+	scriptCmd := appleEscape(shellCmd)
 	script := fmt.Sprintf(`
 		tell application "System Events"
 			set iterm_running to (name of processes) contains "iTerm2"
@@ -255,46 +271,67 @@ func openInTerminalDarwin(editor, filePath string) error {
 				tell current window
 					create tab with default profile
 					tell current session
-						write text "%s %s"
+						write text "%s"
 					end tell
 				end tell
 			end tell
 		else
 			tell application "Terminal"
 				activate
-				do script "%s %s"
+				do script "%s"
 			end tell
 		end if
-	`, editor, shellescape(filePath), editor, shellescape(filePath))
+	`, scriptCmd, scriptCmd)
 	cmd := exec.Command("osascript", "-e", script)
 	return cmd.Start()
 }
 
-func openInTerminalLinux(editor, filePath string) error {
-	// Try common terminal emulators in preference order
+func openInTerminalLinux(editorBin string, args []string) error {
+	// Per-terminal invocation style. Most accept `-e cmd [args…]` with
+	// separate argv tokens, but xfce4-terminal's `-e` expects a single
+	// shell-string, so we POSIX-quote into one arg for it.
+	editorArgv := append([]string{editorBin}, args...)
+	shellCmd := shellJoin(editorArgv)
 	terminals := []struct {
 		cmd  string
-		args func(string, string) []string
+		args []string
 	}{
-		{"ghostty", func(e, f string) []string { return []string{"-e", e, f} }},
-		{"x-terminal-emulator", func(e, f string) []string { return []string{"-e", e, f} }},
-		{"gnome-terminal", func(e, f string) []string { return []string{"--", e, f} }},
-		{"konsole", func(e, f string) []string { return []string{"-e", e, f} }},
-		{"xfce4-terminal", func(e, f string) []string { return []string{"-e", e + " " + f} }},
-		{"xterm", func(e, f string) []string { return []string{"-e", e, f} }},
+		{"ghostty", append([]string{"-e"}, editorArgv...)},
+		{"x-terminal-emulator", append([]string{"-e"}, editorArgv...)},
+		{"gnome-terminal", append([]string{"--"}, editorArgv...)},
+		{"konsole", append([]string{"-e"}, editorArgv...)},
+		{"xfce4-terminal", []string{"-e", shellCmd}},
+		{"xterm", append([]string{"-e"}, editorArgv...)},
 	}
 	for _, t := range terminals {
 		if path, err := exec.LookPath(t.cmd); err == nil {
-			args := t.args(editor, filePath)
-			cmd := exec.Command(path, args...)
+			cmd := exec.Command(path, t.args...)
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 			return cmd.Start()
 		}
 	}
 	return fmt.Errorf("no terminal emulator found; install one or use a GUI editor")
 }
 
-// shellescape does minimal escaping for use inside AppleScript strings.
-func shellescape(s string) string {
+// shellJoin POSIX-quotes each arg and joins with spaces, producing a string
+// safe to pass to `sh -c` or a terminal that expects a single command line.
+func shellJoin(argv []string) string {
+	quoted := make([]string, len(argv))
+	for i, a := range argv {
+		quoted[i] = shellQuote(a)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// shellQuote wraps s in single quotes, escaping any embedded single quotes
+// via the classic `'\''` dance. This is POSIX-safe for any string.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// appleEscape escapes a string for inclusion inside an AppleScript
+// double-quoted string literal.
+func appleEscape(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	return s

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -150,6 +150,31 @@ func TestEditHandlerNoEditor(t *testing.T) {
 	}
 }
 
+// TestEditHandlerWhitespaceEditor guards against a nil-slice panic when
+// the editor env var is non-empty but contains only whitespace: the
+// `s.editor == ""` guard passes, strings.Fields returns an empty slice,
+// and a naive fields[0] indexing crashes the handler. The handler must
+// treat whitespace-only config as "not configured" and return 400.
+func TestEditHandlerWhitespaceEditor(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.md"), []byte("# Hi"), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+	srv, err := NewServer(dir, "   \t  ")
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	handler := srv.Routes()
+
+	req := httptest.NewRequest("POST", "/api/edit/note.md", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestEditHandlerBadPath(t *testing.T) {
 	dir := t.TempDir()
 	srv, err := NewServer(dir, "true")

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -137,6 +137,102 @@ func TestRootRedirect(t *testing.T) {
 	}
 }
 
+func TestEditHandlerNoEditor(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	handler := srv.Routes()
+
+	req := httptest.NewRequest("POST", "/api/edit/README.md", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (no editor)", w.Code)
+	}
+}
+
+func TestEditHandlerBadPath(t *testing.T) {
+	dir := t.TempDir()
+	srv, err := NewServer(dir, "true")
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	handler := srv.Routes()
+
+	req := httptest.NewRequest("POST", "/api/edit/../etc/passwd", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+// TestEditHandlerSimpleEditor pins the success path for a plain editor
+// binary. Uses `true` so the test does not depend on any real editor.
+func TestEditHandlerSimpleEditor(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.md"), []byte("# Hi"), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+	srv, err := NewServer(dir, "true")
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	handler := srv.Routes()
+
+	req := httptest.NewRequest("POST", "/api/edit/note.md", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"status":"ok"`) {
+		t.Errorf("body = %q, want status:ok", w.Body.String())
+	}
+}
+
+// TestEditHandlerEditorWithArgs is the regression guard for #7: an $EDITOR
+// value with embedded arguments (e.g. `subl -w`, `code --wait`,
+// `nvim -R`) must be parsed into binary + args rather than treated as a
+// single binary name, otherwise exec() 500s with "file not found".
+func TestEditHandlerEditorWithArgs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.md"), []byte("# Hi"), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+	// `true` ignores all of these extra flags, so they're harmless, but a
+	// naive exec.Command would look for a literal binary named
+	// `"true --wait"` and fail.
+	srv, err := NewServer(dir, "true --wait -n")
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	handler := srv.Routes()
+
+	req := httptest.NewRequest("POST", "/api/edit/note.md", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := map[string]string{
+		"simple":                `'simple'`,
+		"with space":            `'with space'`,
+		"with'quote":            `'with'\''quote'`,
+		"/path/to/note's me.md": `'/path/to/note'\''s me.md'`,
+	}
+	for in, want := range cases {
+		if got := shellQuote(in); got != want {
+			t.Errorf("shellQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestViewStripsRedundantH1(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	handler := srv.Routes()


### PR DESCRIPTION
## Summary

- Parse `$EDITOR` / `$NOTESVIEW_EDITOR` with `strings.Fields` so values carrying arguments (`subl -w`, `code --wait`, `nvim -R`) resolve to the right binary instead of failing exec.
- Detect TUI editors against `filepath.Base(editorBin)` on the parsed binary, not the raw multi-token string.
- On macOS, invoke `Ghostty.app/Contents/MacOS/ghostty` directly when present instead of routing through `open -na … --args`, which doesn't reliably forward args to a .app bundle.
- Rebuild the AppleScript and `xfce4-terminal` single-string paths on top of a proper POSIX `shellQuote`, so filenames with spaces or quotes survive.
- Add regression tests for editor-with-args, the simple success path, the missing-editor 400, the unsafe-path 400, and `shellQuote`.

## References

- closes #7