### PR TITLE
Fix Vite CJS Node API deprecation warning

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vite'
-import { resolve } from 'path'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   root: 'web/src',


### PR DESCRIPTION
## Summary

- Rename `vite.config.js` to `vite.config.mjs` so Vite loads its Node API via ESM instead of the deprecated CJS path
- Reconstruct `__dirname` from `import.meta.url` since it is unavailable in ESM

## References

- Closes #13
