### PR TITLE
Add structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ notesview serve [flags]
 | `--port`, `-p` | auto | Port to listen on |
 | `--open`, `-o` | false | Open browser on start |
 | `--editor` | `$NOTESVIEW_EDITOR` → `$VISUAL` → `$EDITOR` | Editor command |
+| `--log-level` | `$NOTESVIEW_LOG_LEVEL` → `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `--log-format` | `$NOTESVIEW_LOG_FORMAT` → `text` | Log output format: `text` or `json` |
+| `--log-file` | `$NOTESVIEW_LOG_FILE` | Optional log file path (logs also go to stdout) |
 
 If `--path` points to a file, the server root is set to the file's parent directory and the file is opened directly in the browser (when `--open` is set).
 

--- a/cmd/notesview/serve.go
+++ b/cmd/notesview/serve.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/dreikanter/notesview/internal/logging"
 	"github.com/dreikanter/notesview/internal/server"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +25,9 @@ func init() {
 	serveCmd.Flags().BoolP("open", "o", false, "open browser on start")
 	serveCmd.Flags().String("editor", "", "editor command (default: $NOTESVIEW_EDITOR, $VISUAL, $EDITOR)")
 	serveCmd.Flags().String("path", "", "notes root path or file (default: $NOTESVIEW_PATH, $NOTES_PATH, .)")
+	serveCmd.Flags().String("log-level", "", "log level: debug, info, warn, error (default: $NOTESVIEW_LOG_LEVEL, info)")
+	serveCmd.Flags().String("log-format", "", "log output format: text or json (default: $NOTESVIEW_LOG_FORMAT, text)")
+	serveCmd.Flags().String("log-file", "", "additional log sink file path (default: $NOTESVIEW_LOG_FILE)")
 	rootCmd.AddCommand(serveCmd)
 }
 
@@ -32,6 +36,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	open, _ := cmd.Flags().GetBool("open")
 	editor, _ := cmd.Flags().GetString("editor")
 	path, _ := cmd.Flags().GetString("path")
+	logLevel, _ := cmd.Flags().GetString("log-level")
+	logFormat, _ := cmd.Flags().GetString("log-format")
+	logFile, _ := cmd.Flags().GetString("log-file")
 
 	if editor == "" {
 		for _, env := range []string{"NOTESVIEW_EDITOR", "VISUAL", "EDITOR"} {
@@ -55,17 +62,39 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	path = expandTilde(path)
 
+	if logLevel == "" {
+		logLevel = os.Getenv("NOTESVIEW_LOG_LEVEL")
+	}
+	if logFormat == "" {
+		logFormat = os.Getenv("NOTESVIEW_LOG_FORMAT")
+	}
+	if logFile == "" {
+		logFile = os.Getenv("NOTESVIEW_LOG_FILE")
+	}
+
+	logger, logCloser, err := logging.New(logging.Config{
+		Level:  logLevel,
+		Format: logFormat,
+		File:   logFile,
+	})
+	if err != nil {
+		return fmt.Errorf("configure logger: %w", err)
+	}
+	if logCloser != nil {
+		defer func() { _ = logCloser.Close() }()
+	}
+
 	root, initialFile, err := resolvePath(path)
 	if err != nil {
 		return err
 	}
 
-	srv, err := server.NewServer(root, editor)
+	srv, err := server.NewServer(root, editor, logger)
 	if err != nil {
 		return err
 	}
 	if err := srv.StartWatcher(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: file watcher failed to start: %v\n", err)
+		logger.Warn("file watcher failed to start", "err", err)
 	}
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
@@ -74,7 +103,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	baseURL := "http://" + listener.Addr().String()
-	fmt.Printf("notesview serving %s at %s\n", root, baseURL)
+	logger.Info("notesview serving", "root", root, "url", baseURL)
 
 	if open {
 		target := baseURL

--- a/integration_test.go
+++ b/integration_test.go
@@ -21,7 +21,7 @@ func TestIntegrationSmoke(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "2026", "03", "20260331_9201_todo.md"),
 		[]byte("---\ntitle: Daily Todo\ntags: [todo]\n---\n# Daily Todo\n\n- [+] Done task\n- [ ] Pending task\n- [daily] Routine\n\nSee [readme](../../README.md) and note://20260331_9201.\n"), 0o644)
 
-	srv, err := server.NewServer(dir, "")
+	srv, err := server.NewServer(dir, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,95 @@
+// Package logging builds structured loggers (log/slog) for notesview from a
+// small Config value. The goal is one place where log sinks, level, and
+// format are decided, so the rest of the codebase just takes a *slog.Logger.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Config captures the user-facing logging knobs. Zero value is valid and
+// produces an info-level text logger writing to stdout.
+type Config struct {
+	// Level is one of "debug", "info", "warn", "error". Empty means "info".
+	Level string
+	// Format is "text" or "json". Empty means "text".
+	Format string
+	// File, if non-empty, is an additional log sink opened for append.
+	// Logs are always written to stdout as well.
+	File string
+}
+
+// New builds a *slog.Logger from cfg. When cfg.File is set, it is opened for
+// append (and created if missing, along with any parent dirs) and logs are
+// fanned out to both stdout and the file via io.MultiWriter. The returned
+// io.Closer closes the file sink (nil when no file was opened); callers
+// should close it at shutdown.
+func New(cfg Config) (*slog.Logger, io.Closer, error) {
+	level, err := parseLevel(cfg.Level)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	writers := []io.Writer{os.Stdout}
+	var closer io.Closer
+	if cfg.File != "" {
+		if dir := filepath.Dir(cfg.File); dir != "" && dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return nil, nil, fmt.Errorf("create log dir: %w", err)
+			}
+		}
+		f, err := os.OpenFile(cfg.File, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return nil, nil, fmt.Errorf("open log file: %w", err)
+		}
+		writers = append(writers, f)
+		closer = f
+	}
+
+	handler, err := newHandler(io.MultiWriter(writers...), cfg.Format, level)
+	if err != nil {
+		if closer != nil {
+			_ = closer.Close()
+		}
+		return nil, nil, err
+	}
+	return slog.New(handler), closer, nil
+}
+
+// Discard returns a logger that drops every record. Useful as a default for
+// tests and embedded consumers that don't want log output.
+func Discard() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func newHandler(w io.Writer, format string, level slog.Level) (slog.Handler, error) {
+	opts := &slog.HandlerOptions{Level: level}
+	switch strings.ToLower(format) {
+	case "", "text":
+		return slog.NewTextHandler(w, opts), nil
+	case "json":
+		return slog.NewJSONHandler(w, opts), nil
+	default:
+		return nil, fmt.Errorf("unknown log format %q (want text or json)", format)
+	}
+}
+
+func parseLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(s) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return 0, fmt.Errorf("unknown log level %q (want debug, info, warn, or error)", s)
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,103 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewDefaults(t *testing.T) {
+	ctx := context.Background()
+	logger, closer, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if closer != nil {
+		t.Errorf("expected nil closer when no file configured")
+	}
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+	if !logger.Enabled(ctx, slog.LevelInfo) {
+		t.Errorf("info level should be enabled by default")
+	}
+	if logger.Enabled(ctx, slog.LevelDebug) {
+		t.Errorf("debug level should not be enabled by default")
+	}
+}
+
+func TestNewLevels(t *testing.T) {
+	ctx := context.Background()
+	cases := map[string]slog.Level{
+		"debug":   slog.LevelDebug,
+		"info":    slog.LevelInfo,
+		"warn":    slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"error":   slog.LevelError,
+		"DEBUG":   slog.LevelDebug,
+	}
+	for in, want := range cases {
+		logger, _, err := New(Config{Level: in})
+		if err != nil {
+			t.Errorf("New(%q): %v", in, err)
+			continue
+		}
+		if !logger.Enabled(ctx, want) {
+			t.Errorf("level %q: want %v enabled", in, want)
+		}
+	}
+}
+
+func TestNewInvalidLevel(t *testing.T) {
+	_, _, err := New(Config{Level: "loud"})
+	if err == nil {
+		t.Fatal("expected error for invalid level")
+	}
+}
+
+func TestNewInvalidFormat(t *testing.T) {
+	_, _, err := New(Config{Format: "yaml"})
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+}
+
+func TestNewWithFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "notesview.log")
+
+	logger, closer, err := New(Config{File: path, Format: "json"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if closer == nil {
+		t.Fatal("expected non-nil closer when file configured")
+	}
+	defer func() { _ = closer.Close() }()
+
+	logger.Info("hello", "who", "world")
+
+	// The file should have been created alongside any missing parent dirs
+	// and should contain the JSON-encoded record.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"msg":"hello"`) || !strings.Contains(s, `"who":"world"`) {
+		t.Errorf("log file content = %q, want JSON record with msg/who fields", s)
+	}
+}
+
+func TestDiscardLogger(t *testing.T) {
+	logger := Discard()
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+	// Error is the lowest level we allow through, but output goes to io.Discard,
+	// so this should not panic or produce visible output.
+	logger.Error("dropped")
+}

--- a/internal/server/chrome.go
+++ b/internal/server/chrome.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -47,18 +47,18 @@ func buildBreadcrumbs(path string, isFile bool) []Crumb {
 // buildSidebarTree walks the notes root and produces the nested tree used
 // by the sidebar template. It includes all markdown files and directories,
 // skipping dotfiles.
-func buildSidebarTree(root string) []SidebarNode {
-	return readSidebarDir(root, "")
+func buildSidebarTree(root string, logger *slog.Logger) []SidebarNode {
+	return readSidebarDir(root, "", logger)
 }
 
-func readSidebarDir(root, rel string) []SidebarNode {
+func readSidebarDir(root, rel string, logger *slog.Logger) []SidebarNode {
 	absPath := filepath.Join(root, rel)
 	dirEntries, err := os.ReadDir(absPath)
 	if err != nil {
 		// Log once and degrade gracefully: a read failure in one subtree
 		// (permissions, broken symlink, etc.) shouldn't break the whole
 		// sidebar, but it also shouldn't be completely invisible.
-		log.Printf("notesview: sidebar: read %q: %v", absPath, err)
+		logger.Warn("sidebar read failed", "path", absPath, "err", err)
 		return nil
 	}
 
@@ -81,7 +81,7 @@ func readSidebarDir(root, rel string) []SidebarNode {
 			IsDir: de.IsDir(),
 		}
 		if de.IsDir() {
-			node.Children = readSidebarDir(root, entryRel)
+			node.Children = readSidebarDir(root, entryRel, logger)
 		}
 		nodes = append(nodes, node)
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -29,7 +29,7 @@ func (s *Server) sidebarFor(r *http.Request) []SidebarNode {
 	if r.Header.Get("HX-Request") != "" {
 		return nil
 	}
-	return buildSidebarTree(s.root)
+	return buildSidebarTree(s.root, s.logger)
 }
 
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -15,7 +15,7 @@ func setupTestServer(t *testing.T) (*Server, string) {
 	os.MkdirAll(filepath.Join(dir, "2026", "03"), 0o755)
 	os.WriteFile(filepath.Join(dir, "2026", "03", "20260331_9201_todo.md"), []byte("---\ntitle: Todo\ntags: [todo, daily]\n---\n# Todo\n- [+] Done\n- [ ] Pending\n"), 0o644)
 	os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Welcome\nHello"), 0o644)
-	srv, err := NewServer(dir, "")
+	srv, err := NewServer(dir, "", nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestEditHandlerWhitespaceEditor(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "note.md"), []byte("# Hi"), 0o644); err != nil {
 		t.Fatalf("write note: %v", err)
 	}
-	srv, err := NewServer(dir, "   \t  ")
+	srv, err := NewServer(dir, "   \t  ", nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestEditHandlerWhitespaceEditor(t *testing.T) {
 
 func TestEditHandlerBadPath(t *testing.T) {
 	dir := t.TempDir()
-	srv, err := NewServer(dir, "true")
+	srv, err := NewServer(dir, "true", nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestEditHandlerSimpleEditor(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "note.md"), []byte("# Hi"), 0o644); err != nil {
 		t.Fatalf("write note: %v", err)
 	}
-	srv, err := NewServer(dir, "true")
+	srv, err := NewServer(dir, "true", nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestEditHandlerEditorWithArgs(t *testing.T) {
 	// `true` ignores all of these extra flags, so they're harmless, but a
 	// naive exec.Command would look for a literal binary named
 	// `"true --wait"` and fail.
-	srv, err := NewServer(dir, "true --wait -n")
+	srv, err := NewServer(dir, "true --wait -n", nil)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// logResponseWriter wraps http.ResponseWriter to capture the status code and
+// number of bytes written so the logging middleware can report them after
+// the handler returns. It implements http.Flusher so SSE handlers that cast
+// the writer to http.Flusher keep working.
+type logResponseWriter struct {
+	http.ResponseWriter
+	status int
+	bytes  int
+}
+
+func (w *logResponseWriter) WriteHeader(code int) {
+	if w.status == 0 {
+		w.status = code
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *logResponseWriter) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(b)
+	w.bytes += n
+	return n, err
+}
+
+// Flush exposes the underlying writer's Flush method when it implements
+// http.Flusher. The SSE handler relies on this interface check, so the
+// wrapper has to forward it or live-reload stops working.
+func (w *logResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// logRequests returns middleware that emits a structured record for every
+// HTTP request and its corresponding response. Requests are logged before
+// the handler runs so long-running handlers (e.g. SSE) show up in logs as
+// soon as they connect; responses are logged on return with status, byte
+// count, and duration. Static asset traffic is demoted to debug so a
+// normal page load produces one info record per meaningful request.
+func logRequests(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			level := slog.LevelInfo
+			if isNoisyPath(r.URL.Path) {
+				level = slog.LevelDebug
+			}
+			start := time.Now()
+
+			reqAttrs := []slog.Attr{
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.String("remote", r.RemoteAddr),
+			}
+			if r.URL.RawQuery != "" {
+				reqAttrs = append(reqAttrs, slog.String("query", r.URL.RawQuery))
+			}
+			logger.LogAttrs(r.Context(), level, "http request", reqAttrs...)
+
+			lw := &logResponseWriter{ResponseWriter: w}
+			next.ServeHTTP(lw, r)
+
+			status := lw.status
+			if status == 0 {
+				status = http.StatusOK
+			}
+			respLevel := level
+			switch {
+			case status >= 500:
+				respLevel = slog.LevelError
+			case status >= 400 && respLevel < slog.LevelWarn:
+				respLevel = slog.LevelWarn
+			}
+			logger.LogAttrs(r.Context(), respLevel, "http response",
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", status),
+				slog.Int("bytes", lw.bytes),
+				slog.Duration("duration", time.Since(start)),
+			)
+		})
+	}
+}
+
+// isNoisyPath returns true for request paths that would otherwise spam the
+// log at info level on every page load — currently just static assets.
+func isNoisyPath(path string) bool {
+	return strings.HasPrefix(path, "/static/")
+}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestLogger returns a JSON logger writing into the caller's buffer at
+// debug level so tests can assert on any field the middleware emits.
+func newTestLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestLogRequestsLogsRequestAndResponse(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+
+	mw := logRequests(logger)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+
+	req := httptest.NewRequest("GET", "/view/foo.md?q=1", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	out := buf.String()
+	if !strings.Contains(out, `"msg":"http request"`) {
+		t.Errorf("missing request log: %s", out)
+	}
+	if !strings.Contains(out, `"msg":"http response"`) {
+		t.Errorf("missing response log: %s", out)
+	}
+	if !strings.Contains(out, `"method":"GET"`) {
+		t.Errorf("missing method field: %s", out)
+	}
+	if !strings.Contains(out, `"path":"/view/foo.md"`) {
+		t.Errorf("missing path field: %s", out)
+	}
+	if !strings.Contains(out, `"query":"q=1"`) {
+		t.Errorf("missing query field: %s", out)
+	}
+	if !strings.Contains(out, `"status":200`) {
+		t.Errorf("missing status field: %s", out)
+	}
+	if !strings.Contains(out, `"bytes":5`) {
+		t.Errorf("missing bytes field: %s", out)
+	}
+}
+
+func TestLogRequestsElevatesServerErrors(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+
+	mw := logRequests(logger)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest("GET", "/view/bad", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// The response log line should be at ERROR level for a 500.
+	out := buf.String()
+	if !strings.Contains(out, `"level":"ERROR"`) || !strings.Contains(out, `"msg":"http response"`) {
+		t.Errorf("expected ERROR-level response log, got: %s", out)
+	}
+	if !strings.Contains(out, `"status":500`) {
+		t.Errorf("missing status field: %s", out)
+	}
+}
+
+func TestLogRequestsElevatesClientErrors(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+
+	mw := logRequests(logger)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+
+	req := httptest.NewRequest("GET", "/view/missing.md", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	out := buf.String()
+	// Response line should be WARN for 4xx.
+	if !strings.Contains(out, `"level":"WARN"`) {
+		t.Errorf("expected WARN-level response log, got: %s", out)
+	}
+	if !strings.Contains(out, `"status":404`) {
+		t.Errorf("missing 404 status: %s", out)
+	}
+}
+
+func TestLogRequestsDemotesStaticAssets(t *testing.T) {
+	var buf bytes.Buffer
+	// Info level — debug records should NOT appear at this level.
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	mw := logRequests(logger)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/static/app.js", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected static asset traffic to be silenced at info level, got: %s", buf.String())
+	}
+}
+
+func TestLogResponseWriterFlushPassesThrough(t *testing.T) {
+	// The wrapped writer must still expose http.Flusher so SSE keeps
+	// working. httptest.NewRecorder implements Flusher, so we can assert
+	// that casting our wrapper succeeds.
+	rec := httptest.NewRecorder()
+	lw := &logResponseWriter{ResponseWriter: rec}
+	if _, ok := interface{}(lw).(http.Flusher); !ok {
+		t.Fatalf("logResponseWriter must implement http.Flusher")
+	}
+	// Calling Flush on the wrapper should not panic.
+	lw.Flush()
+}
+
+// TestLogRequestsWithServerRoutes exercises the middleware via the full
+// Server.Routes() wiring, to verify requests flowing through the normal
+// handler stack produce structured log records.
+func TestLogRequestsWithServerRoutes(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+	srv, _ := setupTestServer(t)
+	srv.logger = logger
+	handler := srv.Routes()
+
+	req := httptest.NewRequest("GET", "/view/README.md", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	out := buf.String()
+	if !strings.Contains(out, `"path":"/view/README.md"`) {
+		t.Errorf("expected request path in log: %s", out)
+	}
+	if !strings.Contains(out, `"msg":"http response"`) {
+		t.Errorf("expected response log: %s", out)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,10 +3,12 @@ package server
 import (
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"strings"
 
 	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notesview/internal/logging"
 	"github.com/dreikanter/notesview/internal/renderer"
 	"github.com/dreikanter/notesview/web"
 )
@@ -14,13 +16,21 @@ import (
 type Server struct {
 	root      string
 	editor    string
+	logger    *slog.Logger
 	renderer  *renderer.Renderer
 	index     *index.Index
 	sseHub    *SSEHub
 	templates *templateSet
 }
 
-func NewServer(root, editor string) (*Server, error) {
+// NewServer builds a Server rooted at the given notes directory. The logger
+// is optional: a nil logger is replaced with a discard logger so handlers
+// can always call s.logger.* without a nil check. Callers that want output
+// should pass a logger built via internal/logging.
+func NewServer(root, editor string, logger *slog.Logger) (*Server, error) {
+	if logger == nil {
+		logger = logging.Discard()
+	}
 	idx := index.New(root)
 	idx.Build()
 	tpls, err := loadTemplates()
@@ -30,11 +40,18 @@ func NewServer(root, editor string) (*Server, error) {
 	return &Server{
 		root:      root,
 		editor:    editor,
+		logger:    logger,
 		renderer:  renderer.NewRenderer(idx),
 		index:     idx,
 		sseHub:    NewSSEHub(root),
 		templates: tpls,
 	}, nil
+}
+
+// Logger returns the server's structured logger. Exposed so cmd wiring can
+// share one logger for both request logging and startup messages.
+func (s *Server) Logger() *slog.Logger {
+	return s.logger
 }
 
 func (s *Server) Routes() http.Handler {
@@ -50,7 +67,7 @@ func (s *Server) Routes() http.Handler {
 	staticFS, _ := fs.Sub(web.StaticFS, "static")
 	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 
-	return rejectDirtyPaths(mux)
+	return logRequests(s.logger)(rejectDirtyPaths(mux))
 }
 
 // rejectDirtyPaths returns 400 for any request whose raw URL path is not


### PR DESCRIPTION
## Summary

- New `internal/logging` package wrapping `log/slog` with text/json formats, level, and optional file sink alongside stdout.
- HTTP request/response middleware with 4xx → warn, 5xx → error, `/static/*` demoted to debug.
- `serve` gains `--log-level`, `--log-format`, `--log-file` flags with matching `$NOTESVIEW_LOG_*` env fallbacks.

## References

- Closes #14