### PR TITLE
Use HTML parsing in renderer tests instead of substring matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.8.2
 	github.com/yuin/goldmark-meta v1.1.0
+	golang.org/x/net v0.53.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc
 github.com/yuin/goldmark-meta v1.1.0 h1:pWw+JLHGZe8Rk0EGsMVssiNb/AaPMHfSRszZeUeiOUc=
 github.com/yuin/goldmark-meta v1.1.0/go.mod h1:U4spWENafuA7Zyg+Lj5RqK/MF+ovMYtBvXi1lBb2VP0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/renderer/html_test.go
+++ b/internal/renderer/html_test.go
@@ -1,0 +1,60 @@
+package renderer
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// findAnchor tokenizes rendered HTML and returns the first <a> tag whose
+// attribute attrKey equals attrVal. It fails the test if no match is found.
+func findAnchor(t *testing.T, rendered, attrKey, attrVal string) html.Token {
+	t.Helper()
+	z := html.NewTokenizer(strings.NewReader(rendered))
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+		if tt != html.StartTagToken {
+			continue
+		}
+		tok := z.Token()
+		if tok.DataAtom == 0 && tok.Data != "a" || tok.DataAtom != 0 && tok.Data != "a" {
+			continue
+		}
+		for _, a := range tok.Attr {
+			if a.Key == attrKey && a.Val == attrVal {
+				return tok
+			}
+		}
+	}
+	t.Fatalf("no <a %s=%q> found in:\n%s", attrKey, attrVal, rendered)
+	return html.Token{} // unreachable
+}
+
+// assertAttr asserts that tok carries attribute key with the given value.
+func assertAttr(t *testing.T, tok html.Token, key, val string) {
+	t.Helper()
+	for _, a := range tok.Attr {
+		if a.Key == key {
+			if a.Val != val {
+				t.Errorf("attr %s=%q, want %q (tag: %s)", key, a.Val, val, tok)
+			}
+			return
+		}
+	}
+	t.Errorf("attr %q not found on tag: %s", key, tok)
+}
+
+// assertNoAttr asserts that tok does NOT carry the named attribute.
+func assertNoAttr(t *testing.T, tok html.Token, key string) {
+	t.Helper()
+	for _, a := range tok.Attr {
+		if a.Key == key {
+			t.Errorf("attr %q should be absent, got %s=%q (tag: %s)", key, key, a.Val, tok)
+			return
+		}
+	}
+}

--- a/internal/renderer/noteext.go
+++ b/internal/renderer/noteext.go
@@ -219,10 +219,6 @@ func (r *noteLinkRenderer) renderLink(w util.BufWriter, source []byte, node ast.
 		}
 		_ = w.WriteByte('"')
 
-		// Emit class (if any) before HTMX attrs so tests that check
-		// for "href=... class=..." adjacency match regardless of
-		// whether hx-* is present. Broken-link anchors also benefit:
-		// their class="broken-link" and title="" show up together.
 		if v, ok := n.AttributeString("class"); ok {
 			if b, ok := v.([]byte); ok {
 				_, _ = w.WriteString(` class="`)
@@ -230,7 +226,6 @@ func (r *noteLinkRenderer) renderLink(w util.BufWriter, source []byte, node ast.
 				_ = w.WriteByte('"')
 			}
 		}
-
 		if isInternalLink(n.Destination) {
 			_, _ = w.WriteString(` hx-boost="true" hx-target="#note-pane"`)
 		}

--- a/internal/renderer/noteext_test.go
+++ b/internal/renderer/noteext_test.go
@@ -3,7 +3,6 @@ package renderer
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -19,15 +18,10 @@ func TestWikiLinkResolved(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(html, `href="/view/2026/03/20260331_9201_todo.md"`) {
-		t.Errorf("[[UID]] not resolved:\n%s", html)
-	}
-	if !strings.Contains(html, `class="uid-link"`) {
-		t.Errorf("[[UID]] missing uid-link class:\n%s", html)
-	}
-	if !strings.Contains(html, `hx-boost="true"`) {
-		t.Errorf("[[UID]] missing hx-boost:\n%s", html)
-	}
+	a := findAnchor(t, html, "href", "/view/2026/03/20260331_9201_todo.md")
+	assertAttr(t, a, "class", "uid-link")
+	assertAttr(t, a, "hx-boost", "true")
+	assertAttr(t, a, "hx-target", "#note-pane")
 }
 
 // TestWikiLinkUnresolved verifies that [[UID]] with a non-existent
@@ -72,9 +66,7 @@ func TestWikiLinkDirQuery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(html, `href="/view/2026/03/20260331_9201_todo.md?dir=2026%2F03"`) {
-		t.Errorf("[[UID]] link dropped dirQuery:\n%s", html)
-	}
+	findAnchor(t, html, "href", "/view/2026/03/20260331_9201_todo.md?dir=2026%2F03")
 }
 
 func setupTestIndex(t *testing.T) *index.Index {
@@ -101,10 +93,9 @@ func TestNoteProtocolLink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `<a href="/view/2026/03/20260331_9201_todo.md" hx-boost="true" hx-target="#note-pane"`
-	if !strings.Contains(html, expected) {
-		t.Errorf("note:// link missing expected anchor shape %q:\n%s", expected, html)
-	}
+	a := findAnchor(t, html, "href", "/view/2026/03/20260331_9201_todo.md")
+	assertAttr(t, a, "hx-boost", "true")
+	assertAttr(t, a, "hx-target", "#note-pane")
 }
 
 func TestBrokenNoteLink(t *testing.T) {
@@ -114,20 +105,10 @@ func TestBrokenNoteLink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(html, `class="broken-link"`) {
-		t.Errorf("broken note:// link not marked:\n%s", html)
-	}
-	if !strings.Contains(html, `href="#"`) {
-		t.Errorf("broken link should href=\"#\":\n%s", html)
-	}
-	brokenRe := regexp.MustCompile(`<a [^>]*class="broken-link"[^>]*>`)
-	match := brokenRe.FindString(html)
-	if match == "" {
-		t.Errorf("broken-link anchor not found:\n%s", html)
-	}
-	if strings.Contains(match, "hx-boost") {
-		t.Errorf("broken-link anchor should not have hx-boost, got tag: %s", match)
-	}
+	a := findAnchor(t, html, "class", "broken-link")
+	assertAttr(t, a, "href", "#")
+	assertNoAttr(t, a, "hx-boost")
+	assertNoAttr(t, a, "hx-target")
 }
 
 func TestRelativeMdLink(t *testing.T) {
@@ -137,10 +118,9 @@ func TestRelativeMdLink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `<a href="/view/2026/01/foo.md" hx-boost="true" hx-target="#note-pane"`
-	if !strings.Contains(html, expected) {
-		t.Errorf("relative .md link missing expected anchor shape %q:\n%s", expected, html)
-	}
+	a := findAnchor(t, html, "href", "/view/2026/01/foo.md")
+	assertAttr(t, a, "hx-boost", "true")
+	assertAttr(t, a, "hx-target", "#note-pane")
 }
 
 // TestExternalLinksStayPlain pins the "external links are plain HTML"
@@ -154,16 +134,10 @@ func TestExternalLinksStayPlain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, href := range []string{`href="https://example.com"`, `href="mailto:a@b.com"`, `href="/static/foo.png"`} {
-		if !strings.Contains(html, href) {
-			t.Errorf("expected %s in output:\n%s", href, html)
-		}
-	}
-	// Sanity-check: none of the external-link anchors carry hx-* attrs.
-	if strings.Contains(html, `href="https://example.com" hx-boost`) ||
-		strings.Contains(html, `href="mailto:a@b.com" hx-boost`) ||
-		strings.Contains(html, `href="/static/foo.png" hx-boost`) {
-		t.Errorf("external link picked up hx-boost:\n%s", html)
+	for _, href := range []string{"https://example.com", "mailto:a@b.com", "/static/foo.png"} {
+		a := findAnchor(t, html, "href", href)
+		assertNoAttr(t, a, "hx-boost")
+		assertNoAttr(t, a, "hx-target")
 	}
 }
 
@@ -207,13 +181,8 @@ func TestDirQueryThreading(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(html, `href="/view/2026/03/20260331_9201_todo.md?dir=2026%2F03"`) {
-		t.Errorf("note:// link dropped dirQuery:\n%s", html)
-	}
-	if !strings.Contains(html, `href="/view/2026/03/20260330_9198.md?dir=2026%2F03"`) {
-		t.Errorf("relative .md link dropped dirQuery:\n%s", html)
-	}
-	if !strings.Contains(html, `href="/view/2026/03/20260331_9201_todo.md?dir=2026%2F03" class="uid-link"`) {
-		t.Errorf("[[UID]] wiki-link dropped dirQuery:\n%s", html)
-	}
+	findAnchor(t, html, "href", "/view/2026/03/20260331_9201_todo.md?dir=2026%2F03")
+	findAnchor(t, html, "href", "/view/2026/03/20260330_9198.md?dir=2026%2F03")
+	a := findAnchor(t, html, "class", "uid-link")
+	assertAttr(t, a, "href", "/view/2026/03/20260331_9201_todo.md?dir=2026%2F03")
 }


### PR DESCRIPTION
## Summary

- Add `findAnchor`, `assertAttr`, `assertNoAttr` test helpers using `golang.org/x/net/html` tokenizer
- Migrate all anchor-attribute assertions in `noteext_test.go` from substring/regex matching to parsed HTML checks
- Remove renderer comment about attribute emit order being test-driven

## References

Closes #28