### PR TITLE
Codebase quality audit (closes #26)

### DIFF
--- a/cmd/notesview/main.go
+++ b/cmd/notesview/main.go
@@ -8,8 +8,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "notesview",
-	Short: "Markdown notes viewer with live preview",
+	Use:           "notesview",
+	Short:         "Markdown notes viewer with live preview",
+	SilenceErrors: true,
 }
 
 func main() {

--- a/cmd/notesview/main.go
+++ b/cmd/notesview/main.go
@@ -11,6 +11,7 @@ var rootCmd = &cobra.Command{
 	Use:           "notesview",
 	Short:         "Markdown notes viewer with live preview",
 	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func main() {

--- a/cmd/notesview/serve.go
+++ b/cmd/notesview/serve.go
@@ -129,7 +129,10 @@ func resolvePath(p string) (root, initialFile string, err error) {
 
 func expandTilde(p string) string {
 	if len(p) > 0 && p[0] == '~' {
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return p
+		}
 		return home + p[1:]
 	}
 	return p
@@ -147,5 +150,7 @@ func openBrowser(url string) {
 	default:
 		return
 	}
-	cmd.Start()
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open browser: %v\n", err)
+	}
 }

--- a/cmd/notesview/serve.go
+++ b/cmd/notesview/serve.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/dreikanter/notesview/internal/logging"
 	"github.com/dreikanter/notesview/internal/server"
@@ -121,14 +122,22 @@ func resolvePath(p string) (root, initialFile string, err error) {
 	if err != nil {
 		return "", "", err
 	}
+	var dir string
 	if info.IsDir() {
-		return p, "", nil
+		dir = p
+	} else {
+		dir = filepath.Dir(p)
+		initialFile = filepath.Base(p)
 	}
-	return filepath.Dir(p), filepath.Base(p), nil
+	root, err = filepath.Abs(dir)
+	if err != nil {
+		return "", "", err
+	}
+	return root, initialFile, nil
 }
 
 func expandTilde(p string) string {
-	if len(p) > 0 && p[0] == '~' {
+	if p == "~" || strings.HasPrefix(p, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return p
@@ -152,5 +161,7 @@ func openBrowser(url string) {
 	}
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open browser: %v\n", err)
+		return
 	}
+	go cmd.Wait()
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -32,28 +32,29 @@ func TestIntegrationSmoke(t *testing.T) {
 	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}}
-	resp, err := client.Get(ts.URL + "/")
+	rootResp, err := client.Get(ts.URL + "/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != http.StatusFound {
-		t.Errorf("root: status = %d, want 302", resp.StatusCode)
+	rootResp.Body.Close()
+	if rootResp.StatusCode != http.StatusFound {
+		t.Errorf("root: status = %d, want 302", rootResp.StatusCode)
 	}
 
 	// Test: view a file renders HTML
-	resp, err = http.Get(ts.URL + "/view/2026/03/20260331_9201_todo.md")
+	viewResp, err := http.Get(ts.URL + "/view/2026/03/20260331_9201_todo.md")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("view: status = %d, body: %s", resp.StatusCode, body)
+	defer viewResp.Body.Close()
+	if viewResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(viewResp.Body)
+		t.Fatalf("view: status = %d, body: %s", viewResp.StatusCode, body)
 	}
-	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+	if ct := viewResp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
 		t.Errorf("view: content-type = %q, want text/html", ct)
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := io.ReadAll(viewResp.Body)
 	bodyStr := string(body)
 	if !strings.Contains(bodyStr, "Daily Todo") {
 		t.Errorf("view: expected title 'Daily Todo' in body")
@@ -65,18 +66,17 @@ func TestIntegrationSmoke(t *testing.T) {
 	// Test: /view/README.md?dir=2026 renders a two-pane view with the
 	// sidebar showing 2026/. Dir entries in the sidebar preserve the
 	// note (README.md) and advance the dir.
-	resp, err = http.Get(ts.URL + "/view/README.md?dir=2026")
+	dirResp, err := http.Get(ts.URL + "/view/README.md?dir=2026")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != http.StatusOK {
-		viewErrBody, _ := io.ReadAll(resp.Body)
-		t.Errorf("/view/README.md?dir=2026: status = %d, body: %s", resp.StatusCode, viewErrBody)
-	}
-	viewBody, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	viewBody, err := io.ReadAll(dirResp.Body)
+	dirResp.Body.Close()
 	if err != nil {
 		t.Fatal(err)
+	}
+	if dirResp.StatusCode != http.StatusOK {
+		t.Errorf("/view/README.md?dir=2026: status = %d, body: %s", dirResp.StatusCode, viewBody)
 	}
 	// Sidebar region must be present.
 	if !strings.Contains(string(viewBody), `id="sidebar"`) {
@@ -89,23 +89,23 @@ func TestIntegrationSmoke(t *testing.T) {
 	}
 
 	// Test: raw endpoint
-	resp, err = http.Get(ts.URL + "/api/raw/README.md")
+	rawResp, err := http.Get(ts.URL + "/api/raw/README.md")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	raw, _ := io.ReadAll(resp.Body)
+	raw, _ := io.ReadAll(rawResp.Body)
+	rawResp.Body.Close()
 	if string(raw) != "# Welcome\n\nHello world.\n" {
 		t.Errorf("raw = %q", raw)
 	}
 
 	// Test: 404
-	resp, err = http.Get(ts.URL + "/view/nonexistent.md")
+	notFoundResp, err := http.Get(ts.URL + "/view/nonexistent.md")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("404: status = %d", resp.StatusCode)
+	notFoundResp.Body.Close()
+	if notFoundResp.StatusCode != http.StatusNotFound {
+		t.Errorf("404: status = %d", notFoundResp.StatusCode)
 	}
 }

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -10,14 +10,17 @@ import (
 
 var uidPattern = regexp.MustCompile(`^(\d{8}_\d+)`)
 
+var fullUIDPattern = regexp.MustCompile(`^\d{8}_\d+$`)
+
 func IsUID(s string) bool {
-	return regexp.MustCompile(`^\d{8}_\d+$`).MatchString(s)
+	return fullUIDPattern.MatchString(s)
 }
 
 type Index struct {
-	root string
-	mu   sync.RWMutex
-	uids map[string]string
+	root     string
+	mu       sync.RWMutex
+	uids     map[string]string
+	building sync.Mutex
 }
 
 func New(root string) *Index {
@@ -25,6 +28,18 @@ func New(root string) *Index {
 		root: root,
 		uids: make(map[string]string),
 	}
+}
+
+// Rebuild triggers a background index build, coalescing concurrent calls.
+// If a build is already in progress, the call returns immediately.
+func (idx *Index) Rebuild() {
+	if !idx.building.TryLock() {
+		return
+	}
+	go func() {
+		defer idx.building.Unlock()
+		idx.Build()
+	}()
 }
 
 func (idx *Index) Build() error {

--- a/internal/server/chrome.go
+++ b/internal/server/chrome.go
@@ -8,6 +8,16 @@ import (
 	"strings"
 )
 
+// viewPath percent-encodes each segment of a relative file/dir path for
+// use in /view/ URLs, so names with spaces, #, ? etc. produce valid hrefs.
+func viewPath(relPath string) string {
+	segments := strings.Split(relPath, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return strings.Join(segments, "/")
+}
+
 // dirQuery formats the canonical query suffix that carries the sidebar's
 // sticky directory across links. Empty string means "no sticky directory"
 // (the URL has no ?dir= at all). When non-empty the path is always
@@ -29,13 +39,13 @@ func dirLinkHref(notePath, newDir string) string {
 	if notePath == "" {
 		return "/" + q
 	}
-	return "/view/" + notePath + q
+	return "/view/" + viewPath(notePath) + q
 }
 
 // fileLinkHref builds an href that changes the note while keeping the
 // sidebar on the same directory. The other half of the sticky model.
 func fileLinkHref(filePath, sidebarDir string) string {
-	return "/view/" + filePath + dirQuery(sidebarDir)
+	return "/view/" + viewPath(filePath) + dirQuery(sidebarDir)
 }
 
 // buildBreadcrumbs constructs the sidebar header trail. Intermediate

--- a/internal/server/editor.go
+++ b/internal/server/editor.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+// terminalEditors are editors that need an interactive terminal to run.
+var terminalEditors = map[string]bool{
+	"vim": true, "nvim": true, "vi": true, "nano": true,
+	"emacs": true, "micro": true, "helix": true, "hx": true,
+	"joe": true, "ne": true, "mcedit": true, "ed": true,
+}
+
+// openEditor launches the editor for the given file. GUI editors are spawned
+// directly. Terminal editors are opened in a new terminal window.
+func openEditor(editorBin string, args []string) error {
+	if terminalEditors[filepath.Base(editorBin)] {
+		return openInTerminal(editorBin, args)
+	}
+	cmd := exec.Command(editorBin, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd.Start()
+}
+
+// openInTerminal opens a terminal editor in a new terminal window.
+func openInTerminal(editorBin string, args []string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return openInTerminalDarwin(editorBin, args)
+	case "linux":
+		return openInTerminalLinux(editorBin, args)
+	default:
+		// Fallback: try to run directly (will likely fail for TUI editors
+		// but there's no portable way to open a terminal on this OS)
+		cmd := exec.Command(editorBin, args...)
+		return cmd.Start()
+	}
+}
+
+func openInTerminalDarwin(editorBin string, args []string) error {
+	// Prefer Ghostty via its bundled binary. Launching via
+	// `open -na Ghostty.app --args …` is unreliable for .app bundles
+	// because AppKit doesn't always forward `--args` to the inner
+	// executable, so we invoke the binary directly when it's present.
+	ghosttyBin := "/Applications/Ghostty.app/Contents/MacOS/ghostty"
+	if _, err := os.Stat(ghosttyBin); err == nil {
+		ghosttyArgs := append([]string{"-e", editorBin}, args...)
+		cmd := exec.Command(ghosttyBin, ghosttyArgs...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		return cmd.Start()
+	}
+
+	// Fall back to AppleScript: prefer iTerm2 if running, else Terminal.app.
+	// Both execute a single shell command string, so we POSIX-quote every
+	// argument and concatenate.
+	shellCmd := shellJoin(append([]string{editorBin}, args...))
+	scriptCmd := appleEscape(shellCmd)
+	script := fmt.Sprintf(`
+		tell application "System Events"
+			set iterm_running to (name of processes) contains "iTerm2"
+		end tell
+		if iterm_running then
+			tell application "iTerm2"
+				activate
+				tell current window
+					create tab with default profile
+					tell current session
+						write text "%s"
+					end tell
+				end tell
+			end tell
+		else
+			tell application "Terminal"
+				activate
+				do script "%s"
+			end tell
+		end if
+	`, scriptCmd, scriptCmd)
+	cmd := exec.Command("osascript", "-e", script)
+	return cmd.Start()
+}
+
+func openInTerminalLinux(editorBin string, args []string) error {
+	// Per-terminal invocation style. Most accept `-e cmd [args…]` with
+	// separate argv tokens, but xfce4-terminal's `-e` expects a single
+	// shell-string, so we POSIX-quote into one arg for it.
+	editorArgv := append([]string{editorBin}, args...)
+	shellCmd := shellJoin(editorArgv)
+	terminals := []struct {
+		cmd  string
+		args []string
+	}{
+		{"ghostty", append([]string{"-e"}, editorArgv...)},
+		{"x-terminal-emulator", append([]string{"-e"}, editorArgv...)},
+		{"gnome-terminal", append([]string{"--"}, editorArgv...)},
+		{"konsole", append([]string{"-e"}, editorArgv...)},
+		{"xfce4-terminal", []string{"-e", shellCmd}},
+		{"xterm", append([]string{"-e"}, editorArgv...)},
+	}
+	for _, t := range terminals {
+		if path, err := exec.LookPath(t.cmd); err == nil {
+			cmd := exec.Command(path, t.args...)
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+			return cmd.Start()
+		}
+	}
+	return fmt.Errorf("no terminal emulator found; install one or use a GUI editor")
+}
+
+// shellJoin POSIX-quotes each arg and joins with spaces, producing a string
+// safe to pass to `sh -c` or a terminal that expects a single command line.
+func shellJoin(argv []string) string {
+	quoted := make([]string, len(argv))
+	for i, a := range argv {
+		quoted[i] = shellQuote(a)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// shellQuote wraps s in single quotes, escaping any embedded single quotes
+// via the classic `'\''` dance. This is POSIX-safe for any string.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// appleEscape escapes a string for inclusion inside an AppleScript
+// double-quoted string literal.
+func appleEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}

--- a/internal/server/editor.go
+++ b/internal/server/editor.go
@@ -25,7 +25,11 @@ func openEditor(editorBin string, args []string) error {
 	}
 	cmd := exec.Command(editorBin, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	return cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go cmd.Wait()
+	return nil
 }
 
 // openInTerminal opens a terminal editor in a new terminal window.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -7,11 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"syscall"
 )
 
 // parseDirParam normalizes the ?dir=... query parameter. An empty
@@ -88,7 +85,7 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Warn("sidebar build failed", "dir", sidebarDir, "err", err)
 	}
-	go s.index.Build()
+	s.index.Rebuild()
 
 	view := ViewData{
 		layoutFields: lf,
@@ -290,14 +287,9 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.Write(data)
-}
-
-// terminalEditors are editors that need an interactive terminal to run.
-var terminalEditors = map[string]bool{
-	"vim": true, "nvim": true, "vi": true, "nano": true,
-	"emacs": true, "micro": true, "helix": true, "hx": true,
-	"joe": true, "ne": true, "mcedit": true, "ed": true,
+	if _, err := w.Write(data); err != nil {
+		s.logger.Warn("write response failed", "path", reqPath, "err", err)
+	}
 }
 
 func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
@@ -332,125 +324,7 @@ func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
-}
-
-// openEditor launches the editor for the given file. GUI editors are spawned
-// directly. Terminal editors are opened in a new terminal window.
-func openEditor(editorBin string, args []string) error {
-	if terminalEditors[filepath.Base(editorBin)] {
-		return openInTerminal(editorBin, args)
+	if err := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); err != nil {
+		s.logger.Warn("write response failed", "path", reqPath, "err", err)
 	}
-	cmd := exec.Command(editorBin, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	return cmd.Start()
-}
-
-// openInTerminal opens a terminal editor in a new terminal window.
-func openInTerminal(editorBin string, args []string) error {
-	switch runtime.GOOS {
-	case "darwin":
-		return openInTerminalDarwin(editorBin, args)
-	case "linux":
-		return openInTerminalLinux(editorBin, args)
-	default:
-		// Fallback: try to run directly (will likely fail for TUI editors
-		// but there's no portable way to open a terminal on this OS)
-		cmd := exec.Command(editorBin, args...)
-		return cmd.Start()
-	}
-}
-
-func openInTerminalDarwin(editorBin string, args []string) error {
-	// Prefer Ghostty via its bundled binary. Launching via
-	// `open -na Ghostty.app --args …` is unreliable for .app bundles
-	// because AppKit doesn't always forward `--args` to the inner
-	// executable, so we invoke the binary directly when it's present.
-	ghosttyBin := "/Applications/Ghostty.app/Contents/MacOS/ghostty"
-	if _, err := os.Stat(ghosttyBin); err == nil {
-		ghosttyArgs := append([]string{"-e", editorBin}, args...)
-		cmd := exec.Command(ghosttyBin, ghosttyArgs...)
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-		return cmd.Start()
-	}
-
-	// Fall back to AppleScript: prefer iTerm2 if running, else Terminal.app.
-	// Both execute a single shell command string, so we POSIX-quote every
-	// argument and concatenate.
-	shellCmd := shellJoin(append([]string{editorBin}, args...))
-	scriptCmd := appleEscape(shellCmd)
-	script := fmt.Sprintf(`
-		tell application "System Events"
-			set iterm_running to (name of processes) contains "iTerm2"
-		end tell
-		if iterm_running then
-			tell application "iTerm2"
-				activate
-				tell current window
-					create tab with default profile
-					tell current session
-						write text "%s"
-					end tell
-				end tell
-			end tell
-		else
-			tell application "Terminal"
-				activate
-				do script "%s"
-			end tell
-		end if
-	`, scriptCmd, scriptCmd)
-	cmd := exec.Command("osascript", "-e", script)
-	return cmd.Start()
-}
-
-func openInTerminalLinux(editorBin string, args []string) error {
-	// Per-terminal invocation style. Most accept `-e cmd [args…]` with
-	// separate argv tokens, but xfce4-terminal's `-e` expects a single
-	// shell-string, so we POSIX-quote into one arg for it.
-	editorArgv := append([]string{editorBin}, args...)
-	shellCmd := shellJoin(editorArgv)
-	terminals := []struct {
-		cmd  string
-		args []string
-	}{
-		{"ghostty", append([]string{"-e"}, editorArgv...)},
-		{"x-terminal-emulator", append([]string{"-e"}, editorArgv...)},
-		{"gnome-terminal", append([]string{"--"}, editorArgv...)},
-		{"konsole", append([]string{"-e"}, editorArgv...)},
-		{"xfce4-terminal", []string{"-e", shellCmd}},
-		{"xterm", append([]string{"-e"}, editorArgv...)},
-	}
-	for _, t := range terminals {
-		if path, err := exec.LookPath(t.cmd); err == nil {
-			cmd := exec.Command(path, t.args...)
-			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-			return cmd.Start()
-		}
-	}
-	return fmt.Errorf("no terminal emulator found; install one or use a GUI editor")
-}
-
-// shellJoin POSIX-quotes each arg and joins with spaces, producing a string
-// safe to pass to `sh -c` or a terminal that expects a single command line.
-func shellJoin(argv []string) string {
-	quoted := make([]string, len(argv))
-	for i, a := range argv {
-		quoted[i] = shellQuote(a)
-	}
-	return strings.Join(quoted, " ")
-}
-
-// shellQuote wraps s in single quotes, escaping any embedded single quotes
-// via the classic `'\''` dance. This is POSIX-safe for any string.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
-// appleEscape escapes a string for inclusion inside an AppleScript
-// double-quoted string literal.
-func appleEscape(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	return s
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -34,7 +34,7 @@ func (s *Server) buildLayoutFields(title, editPath, effectiveDir string) layoutF
 		DirQuery: dirQuery(effectiveDir),
 	}
 	if editPath != "" {
-		lf.EditHref = "/api/edit/" + editPath
+		lf.EditHref = "/api/edit/" + viewPath(editPath)
 	}
 	return lf
 }
@@ -160,7 +160,7 @@ func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
 	editHref := ""
 	if s.editor != "" {
 		editPath = reqPath
-		editHref = "/api/edit/" + reqPath
+		editHref = "/api/edit/" + viewPath(reqPath)
 	}
 
 	// Note-pane partial response: return only the note body, no chrome.
@@ -171,7 +171,7 @@ func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
 			Frontmatter: fm,
 			HTML:        template.HTML(html),
 			SSEWatch:    viewSSEWatch(reqPath),
-			ViewHref:    "/view/" + reqPath + dq,
+			ViewHref:    "/view/" + viewPath(reqPath) + dq,
 			DirQuery:    dq,
 			EditPath:    editPath,
 			EditHref:    editHref,
@@ -197,7 +197,7 @@ func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
 		Frontmatter:  fm,
 		HTML:         template.HTML(html),
 		SSEWatch:     viewSSEWatch(reqPath),
-		ViewHref:     "/view/" + reqPath + dq,
+		ViewHref:     "/view/" + viewPath(reqPath) + dq,
 		IndexCard:    card,
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,7 +32,9 @@ func NewServer(root, editor string, logger *slog.Logger) (*Server, error) {
 		logger = logging.Discard()
 	}
 	idx := index.New(root)
-	idx.Build()
+	if err := idx.Build(); err != nil {
+		return nil, fmt.Errorf("initial index build: %w", err)
+	}
 	tpls, err := loadTemplates()
 	if err != nil {
 		return nil, fmt.Errorf("load templates: %w", err)
@@ -43,7 +45,7 @@ func NewServer(root, editor string, logger *slog.Logger) (*Server, error) {
 		logger:    logger,
 		renderer:  renderer.NewRenderer(idx),
 		index:     idx,
-		sseHub:    NewSSEHub(root),
+		sseHub:    NewSSEHub(root, logger),
 		templates: tpls,
 	}, nil
 }
@@ -63,8 +65,12 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /events", s.handleSSE)
 	mux.HandleFunc("GET /", s.handleRoot)
 
-	staticFS, _ := fs.Sub(web.StaticFS, "static")
-	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
+	staticFS, err := fs.Sub(web.StaticFS, "static")
+	if err != nil {
+		s.logger.Error("failed to open embedded static FS", "err", err)
+	} else {
+		mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
+	}
 
 	return logRequests(s.logger)(rejectDirtyPaths(mux))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,7 +45,7 @@ func NewServer(root, editor string, logger *slog.Logger) (*Server, error) {
 		logger:    logger,
 		renderer:  renderer.NewRenderer(idx),
 		index:     idx,
-		sseHub:    NewSSEHub(root, logger),
+		sseHub:    NewSSEHub(root, logger, idx),
 		templates: tpls,
 	}, nil
 }

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ import (
 
 type SSEHub struct {
 	root    string
+	logger  *slog.Logger
 	mu      sync.RWMutex
 	clients map[*sseClient]struct{}
 	watcher *fsnotify.Watcher
@@ -23,9 +25,13 @@ type sseClient struct {
 	events    chan string
 }
 
-func NewSSEHub(root string) *SSEHub {
+func NewSSEHub(root string, logger *slog.Logger) *SSEHub {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
 	return &SSEHub{
 		root:    root,
+		logger:  logger,
 		clients: make(map[*sseClient]struct{}),
 		done:    make(chan struct{}),
 	}
@@ -49,12 +55,14 @@ func (h *SSEHub) Stop() {
 }
 
 func (h *SSEHub) eventLoop() {
-	var debounce *time.Timer
-	var lastPath string
+	timers := make(map[string]*time.Timer)
 
 	for {
 		select {
 		case <-h.done:
+			for _, t := range timers {
+				t.Stop()
+			}
 			return
 		case event, ok := <-h.watcher.Events:
 			if !ok {
@@ -63,17 +71,18 @@ func (h *SSEHub) eventLoop() {
 			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
 				continue
 			}
-			lastPath = event.Name
-			if debounce != nil {
-				debounce.Stop()
+			p := event.Name
+			if t, ok := timers[p]; ok {
+				t.Stop()
 			}
-			debounce = time.AfterFunc(100*time.Millisecond, func() {
-				h.broadcast(lastPath)
+			timers[p] = time.AfterFunc(100*time.Millisecond, func() {
+				h.broadcast(p)
 			})
-		case _, ok := <-h.watcher.Errors:
+		case err, ok := <-h.watcher.Errors:
 			if !ok {
 				return
 			}
+			h.logger.Warn("file watcher error", "err", err)
 		}
 	}
 }
@@ -107,7 +116,22 @@ func (h *SSEHub) addClient(c *sseClient) {
 func (h *SSEHub) removeClient(c *sseClient) {
 	h.mu.Lock()
 	delete(h.clients, c)
+
+	// Remove the watched path if no remaining client needs it.
+	stillWatched := false
+	for other := range h.clients {
+		if other.watchPath == c.watchPath {
+			stillWatched = true
+			break
+		}
+	}
 	h.mu.Unlock()
+
+	if !stillWatched {
+		if absPath, err := SafePath(h.root, c.watchPath); err == nil {
+			h.watcher.Remove(absPath)
+		}
+	}
 }
 
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +158,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	s.sseHub.addClient(client)
 	defer s.sseHub.removeClient(client)
 
-	fmt.Fprintf(w, "event: connected\ndata: %s\n\n", mustJSON(map[string]string{"type": "connected"}))
+	fmt.Fprintf(w, "event: connected\ndata: %s\n\n", toJSON(map[string]string{"type": "connected"}))
 	flusher.Flush()
 
 	ctx := r.Context()
@@ -143,7 +167,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		case <-ctx.Done():
 			return
 		case path := <-client.events:
-			fmt.Fprintf(w, "event: change\ndata: %s\n\n", mustJSON(map[string]string{
+			fmt.Fprintf(w, "event: change\ndata: %s\n\n", toJSON(map[string]string{
 				"type": "change",
 				"path": path,
 			}))
@@ -152,7 +176,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func mustJSON(v interface{}) string {
+func toJSON(v interface{}) string {
 	b, _ := json.Marshal(v)
 	return string(b)
 }

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -108,8 +108,10 @@ func (h *SSEHub) addClient(c *sseClient) {
 	h.mu.Lock()
 	h.clients[c] = struct{}{}
 	h.mu.Unlock()
-	if absPath, err := SafePath(h.root, c.watchPath); err == nil {
-		h.watcher.Add(absPath)
+	if h.watcher != nil {
+		if absPath, err := SafePath(h.root, c.watchPath); err == nil {
+			h.watcher.Add(absPath)
+		}
 	}
 }
 
@@ -127,7 +129,7 @@ func (h *SSEHub) removeClient(c *sseClient) {
 	}
 	h.mu.Unlock()
 
-	if !stillWatched {
+	if !stillWatched && h.watcher != nil {
 		if absPath, err := SafePath(h.root, c.watchPath); err == nil {
 			h.watcher.Remove(absPath)
 		}
@@ -144,6 +146,10 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	watchPath := r.URL.Query().Get("watch")
 	if watchPath == "" {
 		http.Error(w, "watch parameter required", http.StatusBadRequest)
+		return
+	}
+	if _, err := SafePath(s.root, watchPath); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -5,15 +5,18 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/dreikanter/notesview/internal/index"
 	"github.com/fsnotify/fsnotify"
 )
 
 type SSEHub struct {
 	root    string
 	logger  *slog.Logger
+	index   *index.Index
 	mu      sync.RWMutex
 	clients map[*sseClient]struct{}
 	watcher *fsnotify.Watcher
@@ -25,13 +28,14 @@ type sseClient struct {
 	events    chan string
 }
 
-func NewSSEHub(root string, logger *slog.Logger) *SSEHub {
+func NewSSEHub(root string, logger *slog.Logger, idx *index.Index) *SSEHub {
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
 	return &SSEHub{
 		root:    root,
 		logger:  logger,
+		index:   idx,
 		clients: make(map[*sseClient]struct{}),
 		done:    make(chan struct{}),
 	}
@@ -70,6 +74,9 @@ func (h *SSEHub) eventLoop() {
 			}
 			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
 				continue
+			}
+			if event.Op&fsnotify.Create != 0 && h.index != nil {
+				h.index.Rebuild()
 			}
 			p := event.Name
 			if t, ok := timers[p]; ok {
@@ -110,7 +117,11 @@ func (h *SSEHub) addClient(c *sseClient) {
 	h.mu.Unlock()
 	if h.watcher != nil {
 		if absPath, err := SafePath(h.root, c.watchPath); err == nil {
-			h.watcher.Add(absPath)
+			// Watch the parent directory instead of the file itself.
+			// Many editors (vim, emacs, IDEs) save via write-to-temp +
+			// rename, which replaces the inode. Watching the directory
+			// ensures we see the rename/create event for the new inode.
+			h.watcher.Add(filepath.Dir(absPath))
 		}
 	}
 }
@@ -119,20 +130,27 @@ func (h *SSEHub) removeClient(c *sseClient) {
 	h.mu.Lock()
 	delete(h.clients, c)
 
-	// Remove the watched path if no remaining client needs it.
-	stillWatched := false
-	for other := range h.clients {
-		if other.watchPath == c.watchPath {
-			stillWatched = true
-			break
+	// Remove the watched directory if no remaining client needs it.
+	// We check whether any other client watches a file in the same
+	// directory, not just the exact same file.
+	var dirToRemove string
+	if h.watcher != nil {
+		if absPath, err := SafePath(h.root, c.watchPath); err == nil {
+			dirToRemove = filepath.Dir(absPath)
+			for other := range h.clients {
+				if otherAbs, err := SafePath(h.root, other.watchPath); err == nil {
+					if filepath.Dir(otherAbs) == dirToRemove {
+						dirToRemove = ""
+						break
+					}
+				}
+			}
 		}
 	}
 	h.mu.Unlock()
 
-	if !stillWatched && h.watcher != nil {
-		if absPath, err := SafePath(h.root, c.watchPath); err == nil {
-			h.watcher.Remove(absPath)
-		}
+	if dirToRemove != "" {
+		h.watcher.Remove(dirToRemove)
 	}
 }
 

--- a/internal/server/sse_test.go
+++ b/internal/server/sse_test.go
@@ -15,7 +15,7 @@ func TestSSEConnection(t *testing.T) {
 	testFile := filepath.Join(dir, "test.md")
 	os.WriteFile(testFile, []byte("# Test"), 0o644)
 
-	hub := NewSSEHub(dir)
+	hub := NewSSEHub(dir, nil)
 	hub.Start()
 	defer hub.Stop()
 
@@ -46,7 +46,7 @@ func TestSSEConnection(t *testing.T) {
 
 func TestSSEHubClientCleanup(t *testing.T) {
 	dir := t.TempDir()
-	hub := NewSSEHub(dir)
+	hub := NewSSEHub(dir, nil)
 	hub.Start()
 	defer hub.Stop()
 

--- a/internal/server/sse_test.go
+++ b/internal/server/sse_test.go
@@ -15,7 +15,7 @@ func TestSSEConnection(t *testing.T) {
 	testFile := filepath.Join(dir, "test.md")
 	os.WriteFile(testFile, []byte("# Test"), 0o644)
 
-	hub := NewSSEHub(dir, nil)
+	hub := NewSSEHub(dir, nil, nil)
 	hub.Start()
 	defer hub.Stop()
 
@@ -46,7 +46,7 @@ func TestSSEConnection(t *testing.T) {
 
 func TestSSEHubClientCleanup(t *testing.T) {
 	dir := t.TempDir()
-	hub := NewSSEHub(dir, nil)
+	hub := NewSSEHub(dir, nil, nil)
 	hub.Start()
 	defer hub.Stop()
 


### PR DESCRIPTION
## Summary

**Error handling**
- Handle swallowed errors: `fs.Sub` in Routes, `expandTilde`, `openBrowser`, `w.Write` in handleRaw, `json.Encode` in handleEdit, `idx.Build` in NewServer, fsnotify watcher errors in SSE hub
- Silence cobra's built-in error printing to avoid double output; suppress usage text on runtime errors

**SSE / live reload**
- Watch parent directories instead of individual files so editors that save via write-to-temp + rename (vim, emacs, IDEs) still trigger live reload
- Fix debounce dropping events for different files — use per-path timers instead of a single global timer
- Fix watcher file descriptor leak — clean up watched directories when no clients remain
- Guard watcher calls against nil to prevent panic when watcher failed to start
- Validate SSE `watch` parameter with SafePath before registering client
- Rebuild UID index on file Create events so new notes are immediately resolvable

**Code quality**
- Fix `IsUID()` recompiling regex on every call — reuse package-level pattern
- Rename `mustJSON` to `toJSON` (Go convention: `must*` implies panic)
- Extract editor subsystem from `handlers.go` into `editor.go`
- Deduplicate concurrent index rebuilds with `Index.Rebuild()` using `sync.Mutex.TryLock`
- Reap GUI editor and browser child processes to prevent zombies

**CLI / usability**
- Fix `expandTilde` mangling `~user` paths — only expand `~` and `~/` prefix
- Absolutize root path in `resolvePath` for consistent logging and SafePath
- Percent-encode path segments in `/view/` and `/api/edit/` hrefs

**Tests**
- Fix integration test `defer resp.Body.Close()` capturing last variable instead of each response

## Issue validation

Several items from the original issue are no longer relevant:
- `chrome.go` identical branches — already fixed in a prior refactor
- `BrowseEntry` cross-boundary type — no longer exists
- `notelinks.go` `splitByTags()` — function doesn't exist in the codebase

## References

- Closes #26