### PR TITLE
Add renderer tests for frontmatter parsing and stripRedundantTitle

### DIFF
--- a/internal/renderer/renderer_test.go
+++ b/internal/renderer/renderer_test.go
@@ -1,0 +1,255 @@
+package renderer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFrontmatterMissing(t *testing.T) {
+	r := NewRenderer(nil)
+	html, fm, err := r.Render([]byte("# Hello\n\nSome text."), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm != nil {
+		t.Errorf("expected nil frontmatter, got %+v", fm)
+	}
+	if !strings.Contains(html, "Hello") {
+		t.Errorf("expected HTML to contain heading, got: %s", html)
+	}
+}
+
+func TestFrontmatterEmpty(t *testing.T) {
+	r := NewRenderer(nil)
+	html, fm, err := r.Render([]byte("---\n---\n# Hello"), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter for empty YAML block")
+	}
+	if fm.Title != "" || fm.Description != "" || fm.Slug != "" || len(fm.Tags) != 0 {
+		t.Errorf("expected all fields empty, got %+v", fm)
+	}
+	if !strings.Contains(html, "Hello") {
+		t.Errorf("expected HTML to contain heading, got: %s", html)
+	}
+}
+
+func TestFrontmatterTitleOnly(t *testing.T) {
+	r := NewRenderer(nil)
+	_, fm, err := r.Render([]byte("---\ntitle: My Note\n---\nBody."), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter")
+	}
+	if fm.Title != "My Note" {
+		t.Errorf("title = %q, want %q", fm.Title, "My Note")
+	}
+	if fm.Description != "" || fm.Slug != "" || len(fm.Tags) != 0 {
+		t.Errorf("expected other fields empty, got %+v", fm)
+	}
+}
+
+func TestFrontmatterTagsOnly(t *testing.T) {
+	r := NewRenderer(nil)
+	_, fm, err := r.Render([]byte("---\ntags:\n  - go\n  - testing\n---\nBody."), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter")
+	}
+	if fm.Title != "" {
+		t.Errorf("title should be empty, got %q", fm.Title)
+	}
+	if len(fm.Tags) != 2 || fm.Tags[0] != "go" || fm.Tags[1] != "testing" {
+		t.Errorf("tags = %v, want [go testing]", fm.Tags)
+	}
+}
+
+func TestFrontmatterAllFields(t *testing.T) {
+	r := NewRenderer(nil)
+	input := "---\ntitle: Full\ndescription: A note\nslug: full-note\ntags:\n  - a\n  - b\n---\nBody."
+	_, fm, err := r.Render([]byte(input), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter")
+	}
+	if fm.Title != "Full" {
+		t.Errorf("title = %q, want %q", fm.Title, "Full")
+	}
+	if fm.Description != "A note" {
+		t.Errorf("description = %q, want %q", fm.Description, "A note")
+	}
+	if fm.Slug != "full-note" {
+		t.Errorf("slug = %q, want %q", fm.Slug, "full-note")
+	}
+	if len(fm.Tags) != 2 || fm.Tags[0] != "a" || fm.Tags[1] != "b" {
+		t.Errorf("tags = %v, want [a b]", fm.Tags)
+	}
+}
+
+func TestFrontmatterMalformedYAML(t *testing.T) {
+	r := NewRenderer(nil)
+	// Scalar value instead of a mapping — goldmark-meta returns nil
+	// because it expects a YAML map.
+	_, fm, err := r.Render([]byte("---\njust a string\n---\nBody."), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm != nil {
+		t.Errorf("expected nil frontmatter for non-mapping YAML, got %+v", fm)
+	}
+	_ = r
+}
+
+func TestFrontmatterUnknownKeys(t *testing.T) {
+	r := NewRenderer(nil)
+	// Valid YAML mapping but with keys we don't recognize — fm is
+	// non-nil but all known fields should be zero-valued.
+	_, fm, err := r.Render([]byte("---\nauthor: Jane\nrating: 5\n---\nBody."), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter for valid YAML mapping")
+	}
+	if fm.Title != "" || fm.Description != "" || fm.Slug != "" || len(fm.Tags) != 0 {
+		t.Errorf("expected all known fields empty, got %+v", fm)
+	}
+	_ = r
+}
+
+func TestFrontmatterWrongTypes(t *testing.T) {
+	r := NewRenderer(nil)
+	// title is a list, tags is a string — wrong types for our mapping.
+	input := "---\ntitle:\n  - not\n  - a string\ntags: just-a-string\n---\nBody."
+	_, fm, err := r.Render([]byte(input), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter")
+	}
+	if fm.Title != "" {
+		t.Errorf("title should be empty for non-string value, got %q", fm.Title)
+	}
+	if len(fm.Tags) != 0 {
+		t.Errorf("tags should be empty for non-list value, got %v", fm.Tags)
+	}
+}
+
+func TestEmptyDocument(t *testing.T) {
+	r := NewRenderer(nil)
+	html, fm, err := r.Render([]byte(""), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if fm != nil {
+		t.Errorf("expected nil frontmatter for empty input, got %+v", fm)
+	}
+	if html != "" {
+		t.Errorf("expected empty HTML for empty input, got %q", html)
+	}
+}
+
+func TestStripRedundantTitleExact(t *testing.T) {
+	r := NewRenderer(nil)
+	input := "---\ntitle: Hello World\n---\n# Hello World\n\nBody text."
+	html, _, err := r.Render([]byte(input), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if strings.Contains(html, "<h1") {
+		t.Errorf("redundant <h1> should be stripped, got: %s", html)
+	}
+	if !strings.Contains(html, "Body text") {
+		t.Errorf("body text should be preserved, got: %s", html)
+	}
+}
+
+func TestStripRedundantTitleHTMLEntities(t *testing.T) {
+	r := NewRenderer(nil)
+	// Goldmark renders "A & B" in a heading as "A &amp; B".
+	// stripRedundantTitle should decode entities before comparing.
+	input := "---\ntitle: A & B\n---\n# A & B\n\nBody."
+	html, _, err := r.Render([]byte(input), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if strings.Contains(html, "<h1") {
+		t.Errorf("h1 with HTML entities should be stripped when matching title, got: %s", html)
+	}
+}
+
+func TestStripRedundantTitleInlineMarkup(t *testing.T) {
+	r := NewRenderer(nil)
+	// "# **Bold** title" renders as <h1><strong>Bold</strong> title</h1>.
+	// After stripping inner tags, the plain text is "Bold title".
+	input := "---\ntitle: Bold title\n---\n# **Bold** title\n\nBody."
+	html, _, err := r.Render([]byte(input), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if strings.Contains(html, "<h1") {
+		t.Errorf("h1 with inline markup should be stripped when plain text matches title, got: %s", html)
+	}
+}
+
+func TestStripRedundantTitleMismatch(t *testing.T) {
+	r := NewRenderer(nil)
+	// When the h1 content doesn't match the frontmatter title, keep it.
+	input := "---\ntitle: Actual Title\n---\n# Different Heading\n\nBody."
+	html, _, err := r.Render([]byte(input), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if !strings.Contains(html, "<h1") {
+		t.Errorf("non-matching h1 should be preserved, got: %s", html)
+	}
+	if !strings.Contains(html, "Different Heading") {
+		t.Errorf("heading text should be preserved, got: %s", html)
+	}
+}
+
+func TestStripRedundantTitleLeadingWhitespace(t *testing.T) {
+	// The leadingH1 regex tolerates leading whitespace before <h1>.
+	got := stripRedundantTitle("  \n<h1>Hello</h1>\n<p>Body</p>", "Hello")
+	if strings.Contains(got, "<h1") {
+		t.Errorf("leading whitespace before h1 should still match, got: %s", got)
+	}
+	if !strings.Contains(got, "<p>Body</p>") {
+		t.Errorf("body should be preserved, got: %s", got)
+	}
+}
+
+func TestStripRedundantTitleNoH1(t *testing.T) {
+	r := NewRenderer(nil)
+	// Document with a title in frontmatter but no h1 in the body.
+	input := "---\ntitle: My Title\n---\n## Subtitle\n\nBody."
+	html, _, err := r.Render([]byte(input), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if !strings.Contains(html, "Subtitle") {
+		t.Errorf("h2 should be preserved, got: %s", html)
+	}
+}
+
+func TestStripRedundantTitleNoFrontmatterTitle(t *testing.T) {
+	r := NewRenderer(nil)
+	// Frontmatter exists but has no title — h1 should be preserved.
+	input := "---\ntags:\n  - go\n---\n# Keep This\n\nBody."
+	html, _, err := r.Render([]byte(input), "", "")
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	if !strings.Contains(html, "<h1") {
+		t.Errorf("h1 should be preserved when frontmatter has no title, got: %s", html)
+	}
+}

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -1,0 +1,289 @@
+package server
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/dreikanter/notesview/internal/renderer"
+)
+
+func TestLoadTemplates(t *testing.T) {
+	ts, err := loadTemplates()
+	if err != nil {
+		t.Fatalf("loadTemplates() error: %v", err)
+	}
+	if ts.view == nil {
+		t.Error("view template is nil")
+	}
+	if ts.sidebar == nil {
+		t.Error("sidebar template is nil")
+	}
+	if ts.note == nil {
+		t.Error("note template is nil")
+	}
+}
+
+func TestLoadTemplates_DefinedTemplates(t *testing.T) {
+	ts, err := loadTemplates()
+	if err != nil {
+		t.Fatalf("loadTemplates() error: %v", err)
+	}
+
+	// The view template should include layout and all partials.
+	for _, name := range []string{"layout", "sidebar_body", "note_pane_body", "breadcrumbs", "index_card"} {
+		if ts.view.Lookup(name) == nil {
+			t.Errorf("view template set missing %q", name)
+		}
+	}
+}
+
+func TestParsePage(t *testing.T) {
+	tmpl, err := parsePage("templates/view.html")
+	if err != nil {
+		t.Fatalf("parsePage() error: %v", err)
+	}
+
+	// Should include the page plus all partials.
+	for _, name := range []string{"layout", "sidebar_body", "note_pane_body", "breadcrumbs", "index_card"} {
+		if tmpl.Lookup(name) == nil {
+			t.Errorf("parsePage result missing template %q", name)
+		}
+	}
+}
+
+func TestParsePartial_SidebarBody(t *testing.T) {
+	tmpl, err := parsePartial("sidebar_body")
+	if err != nil {
+		t.Fatalf("parsePartial(sidebar_body) error: %v", err)
+	}
+	if tmpl.Lookup("sidebar_body") == nil {
+		t.Error("sidebar_body template not defined")
+	}
+}
+
+func TestParsePartial_NotePaneBody(t *testing.T) {
+	tmpl, err := parsePartial("note_pane_body")
+	if err != nil {
+		t.Fatalf("parsePartial(note_pane_body) error: %v", err)
+	}
+	if tmpl.Lookup("note_pane_body") == nil {
+		t.Error("note_pane_body template not defined")
+	}
+}
+
+func TestRenderView(t *testing.T) {
+	ts, err := loadTemplates()
+	if err != nil {
+		t.Fatalf("loadTemplates() error: %v", err)
+	}
+
+	data := ViewData{
+		layoutFields: layoutFields{
+			Title:    "Test Note",
+			EditPath: "notes/test.md",
+			EditHref: "/edit/notes/test.md",
+			DirQuery: "?dir=notes",
+		},
+		NotePath:  "notes/test.md",
+		NoteTitle: "Test Note",
+		Frontmatter: &renderer.Frontmatter{
+			Title:       "Test Note",
+			Tags:        []string{"go", "testing"},
+			Description: "A test note",
+		},
+		HTML:     template.HTML("<p>Hello world</p>"),
+		SSEWatch: "/events?watch=notes%2Ftest.md",
+		ViewHref: "/view/notes/test.md?dir=notes",
+		IndexCard: &IndexCard{
+			Mode: "dir",
+			Breadcrumbs: BreadcrumbsData{
+				HomeHref: "/view/",
+				Crumbs:   []Crumb{{Label: "notes", Href: "/view/notes/", Current: true}},
+			},
+			Entries: []IndexEntry{
+				{Name: "test.md", IsDir: false, Href: "/view/notes/test.md"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := ts.renderView(&buf, data); err != nil {
+		t.Fatalf("renderView() error: %v", err)
+	}
+
+	body := buf.String()
+	checks := []struct {
+		label    string
+		contains string
+	}{
+		{"doctype", "<!DOCTYPE html>"},
+		{"title", "Test Note — notesview"},
+		{"note content", "Hello world"},
+		{"frontmatter title", ">Test Note<"},
+		{"tag go", ">go<"},
+		{"tag testing", ">testing<"},
+		{"description", "A test note"},
+		{"sse-connect", `sse-connect="/events?watch=notes%2Ftest.md"`},
+		{"sidebar", `id="sidebar"`},
+		{"note-pane", `id="note-pane"`},
+		{"edit button", `/edit/notes/test.md`},
+	}
+
+	for _, c := range checks {
+		if !strings.Contains(body, c.contains) {
+			t.Errorf("renderView: expected %s (%q) in output", c.label, c.contains)
+		}
+	}
+}
+
+func TestRenderView_EmptyTitle(t *testing.T) {
+	ts, err := loadTemplates()
+	if err != nil {
+		t.Fatalf("loadTemplates() error: %v", err)
+	}
+
+	data := ViewData{
+		HTML: template.HTML("<p>No title</p>"),
+	}
+
+	var buf bytes.Buffer
+	if err := ts.renderView(&buf, data); err != nil {
+		t.Fatalf("renderView() error: %v", err)
+	}
+
+	body := buf.String()
+	// When Title is empty, the page title should just be "notesview" without a dash.
+	if !strings.Contains(body, "<title>notesview</title>") {
+		t.Error("expected plain 'notesview' title when Title is empty")
+	}
+}
+
+func TestRenderNotePartial(t *testing.T) {
+	ts, err := loadTemplates()
+	if err != nil {
+		t.Fatalf("loadTemplates() error: %v", err)
+	}
+
+	data := NotePartialData{
+		NotePath:  "2026/03/note.md",
+		NoteTitle: "March Note",
+		Frontmatter: &renderer.Frontmatter{
+			Title: "March Note",
+			Tags:  []string{"journal"},
+		},
+		HTML:     template.HTML("<p>Partial content</p>"),
+		SSEWatch: "/events?watch=2026%2F03%2Fnote.md",
+		ViewHref: "/view/2026/03/note.md",
+		EditPath: "2026/03/note.md",
+		EditHref: "/edit/2026/03/note.md",
+	}
+
+	var buf bytes.Buffer
+	if err := ts.renderNotePartial(&buf, data); err != nil {
+		t.Fatalf("renderNotePartial() error: %v", err)
+	}
+
+	body := buf.String()
+	checks := []struct {
+		label    string
+		contains string
+	}{
+		{"note card", `id="note-card"`},
+		{"note title", ">March Note<"},
+		{"tag", ">journal<"},
+		{"content", "Partial content"},
+		{"sse-connect", `sse-connect="/events?watch=2026%2F03%2Fnote.md"`},
+		{"edit button", `/edit/2026/03/note.md`},
+	}
+
+	for _, c := range checks {
+		if !strings.Contains(body, c.contains) {
+			t.Errorf("renderNotePartial: expected %s (%q) in output", c.label, c.contains)
+		}
+	}
+
+	// Should NOT contain full layout elements.
+	if strings.Contains(body, "<!DOCTYPE html>") {
+		t.Error("renderNotePartial should not contain full HTML document")
+	}
+}
+
+func TestRenderSidebarPartial(t *testing.T) {
+	ts, err := loadTemplates()
+	if err != nil {
+		t.Fatalf("loadTemplates() error: %v", err)
+	}
+
+	data := SidebarPartialData{
+		IndexCard: &IndexCard{
+			Mode: "dir",
+			Breadcrumbs: BreadcrumbsData{
+				HomeHref: "/view/",
+				Crumbs:   []Crumb{{Label: "docs", Href: "/view/docs/", Current: true}},
+			},
+			Entries: []IndexEntry{
+				{Name: "readme.md", IsDir: false, Href: "/view/docs/readme.md"},
+				{Name: "subdir", IsDir: true, Href: "/view/docs/subdir/"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := ts.renderSidebarPartial(&buf, data); err != nil {
+		t.Fatalf("renderSidebarPartial() error: %v", err)
+	}
+
+	body := buf.String()
+	if !strings.Contains(body, "readme.md") {
+		t.Error("renderSidebarPartial: expected file entry 'readme.md'")
+	}
+	if !strings.Contains(body, "subdir") {
+		t.Error("renderSidebarPartial: expected directory entry 'subdir'")
+	}
+	if !strings.Contains(body, "docs") {
+		t.Error("renderSidebarPartial: expected breadcrumb 'docs'")
+	}
+
+	// Should NOT contain full layout elements.
+	if strings.Contains(body, "<!DOCTYPE html>") {
+		t.Error("renderSidebarPartial should not contain full HTML document")
+	}
+}
+
+func TestRenderSidebarPartial_NilIndexCard(t *testing.T) {
+	ts, err := loadTemplates()
+	if err != nil {
+		t.Fatalf("loadTemplates() error: %v", err)
+	}
+
+	data := SidebarPartialData{IndexCard: nil}
+
+	var buf bytes.Buffer
+	if err := ts.renderSidebarPartial(&buf, data); err != nil {
+		t.Fatalf("renderSidebarPartial() with nil IndexCard error: %v", err)
+	}
+}
+
+func TestRenderNotePartial_NoFrontmatter(t *testing.T) {
+	ts, err := loadTemplates()
+	if err != nil {
+		t.Fatalf("loadTemplates() error: %v", err)
+	}
+
+	data := NotePartialData{
+		NotePath: "plain.md",
+		HTML:     template.HTML("<p>Plain note</p>"),
+	}
+
+	var buf bytes.Buffer
+	if err := ts.renderNotePartial(&buf, data); err != nil {
+		t.Fatalf("renderNotePartial() error: %v", err)
+	}
+
+	body := buf.String()
+	if !strings.Contains(body, "Plain note") {
+		t.Error("expected note content in output")
+	}
+}


### PR DESCRIPTION
## Summary

- Add edge-case tests for frontmatter parsing: missing, empty, partial (title-only, tags-only), all fields, malformed YAML, unknown keys, and wrong types
- Add tests for `stripRedundantTitle`: exact match, HTML entities (`&amp;`), inline markup (`**bold**`), non-matching title, leading whitespace, no `<h1>`, and no frontmatter title
- Add empty document test

## References

Closes #35