### PR TITLE
Add graceful shutdown for clean resource cleanup

### DIFF
--- a/cmd/notesview/serve.go
+++ b/cmd/notesview/serve.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/dreikanter/notesview/internal/logging"
 	"github.com/dreikanter/notesview/internal/server"
@@ -114,7 +119,27 @@ func runServe(cmd *cobra.Command, args []string) error {
 		openBrowser(target)
 	}
 
-	return http.Serve(listener, srv.Routes())
+	httpServer := &http.Server{Handler: srv.Routes()}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		logger.Info("shutting down")
+		srv.Shutdown()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(ctx); err != nil {
+			logger.Warn("http server shutdown error", "err", err)
+		}
+	}()
+
+	if err := httpServer.Serve(listener); !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }
 
 func resolvePath(p string) (root, initialFile string, err error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,3 +92,9 @@ func rejectDirtyPaths(next http.Handler) http.Handler {
 func (s *Server) StartWatcher() error {
 	return s.sseHub.Start()
 }
+
+// Shutdown stops the SSE hub, closing the fsnotify watcher and draining
+// connected clients.
+func (s *Server) Shutdown() {
+	s.sseHub.Stop()
+}

--- a/internal/server/sse_test.go
+++ b/internal/server/sse_test.go
@@ -44,6 +44,23 @@ func TestSSEConnection(t *testing.T) {
 	}
 }
 
+func TestServerShutdownStopsHub(t *testing.T) {
+	dir := t.TempDir()
+	hub := NewSSEHub(dir, nil, nil)
+	hub.Start()
+
+	srv := &Server{root: dir, sseHub: hub}
+	srv.Shutdown()
+
+	// After Shutdown, the done channel should be closed.
+	select {
+	case <-hub.done:
+		// expected
+	default:
+		t.Fatal("expected hub.done to be closed after Shutdown")
+	}
+}
+
 func TestSSEHubClientCleanup(t *testing.T) {
 	dir := t.TempDir()
 	hub := NewSSEHub(dir, nil, nil)


### PR DESCRIPTION
## Summary

- Listen for SIGINT/SIGTERM in `runServe` and shut down cleanly: stop the SSE hub (closing the fsnotify watcher and draining SSE clients), then shut down the HTTP server with a 5-second timeout
- Switch from `http.Serve` to `http.Server` struct to enable `Shutdown(ctx)`
- Add `Server.Shutdown()` method and a unit test for it

## References

- Closes #37