### PR TITLE
Handle WalkDir errors in Index.Build instead of silently skipping

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"errors"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -29,7 +30,7 @@ type Index struct {
 
 func New(root string, logger *slog.Logger) *Index {
 	if logger == nil {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 	return &Index{
 		root:   root,

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -1,6 +1,9 @@
 package index
 
 import (
+	"errors"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,15 +21,20 @@ func IsUID(s string) bool {
 
 type Index struct {
 	root     string
+	logger   *slog.Logger
 	mu       sync.RWMutex
 	uids     map[string]string
 	building sync.Mutex
 }
 
-func New(root string) *Index {
+func New(root string, logger *slog.Logger) *Index {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+	}
 	return &Index{
-		root: root,
-		uids: make(map[string]string),
+		root:   root,
+		logger: logger,
+		uids:   make(map[string]string),
 	}
 }
 
@@ -38,7 +46,9 @@ func (idx *Index) Rebuild() {
 	}
 	go func() {
 		defer idx.building.Unlock()
-		idx.Build()
+		if err := idx.Build(); err != nil {
+			idx.logger.Error("index rebuild failed", "err", err)
+		}
 	}()
 }
 
@@ -46,7 +56,11 @@ func (idx *Index) Build() error {
 	uids := make(map[string]string)
 	err := filepath.WalkDir(idx.root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil
+			if errors.Is(err, fs.ErrPermission) {
+				idx.logger.Warn("skipping path: permission denied", "path", path)
+				return filepath.SkipDir
+			}
+			return err
 		}
 		if d.IsDir() {
 			return nil

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -2,7 +2,6 @@ package index
 
 import (
 	"errors"
-	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -10,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/dreikanter/notesview/internal/logging"
 )
 
 var uidPattern = regexp.MustCompile(`^(\d{8}_\d+)`)
@@ -30,7 +31,7 @@ type Index struct {
 
 func New(root string, logger *slog.Logger) *Index {
 	if logger == nil {
-		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+		logger = logging.Discard()
 	}
 	return &Index{
 		root:   root,

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -1,8 +1,12 @@
 package index
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -20,7 +24,7 @@ func setupTestDir(t *testing.T) string {
 
 func TestIndexBuild(t *testing.T) {
 	dir := setupTestDir(t)
-	idx := New(dir)
+	idx := New(dir, nil)
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build failed: %v", err)
 	}
@@ -46,6 +50,57 @@ func TestIndexBuild(t *testing.T) {
 				t.Errorf("Lookup(%q) = %q, want %q", tt.uid, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildSkipsUnreadableDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-based test not reliable on Windows")
+	}
+
+	dir := setupTestDir(t)
+
+	// Create a subdirectory that is not readable.
+	unreadable := filepath.Join(dir, "2026", "secret")
+	if err := os.MkdirAll(unreadable, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(unreadable, "20260401_0001.md"), []byte("# Secret"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o755) })
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	idx := New(dir, logger)
+	if err := idx.Build(); err != nil {
+		t.Fatalf("Build returned unexpected error: %v", err)
+	}
+
+	// Files in readable dirs should still be indexed.
+	if _, ok := idx.Lookup("20260331_9201"); !ok {
+		t.Error("expected 20260331_9201 to be indexed")
+	}
+
+	// File in the unreadable dir should be skipped.
+	if _, ok := idx.Lookup("20260401_0001"); ok {
+		t.Error("expected 20260401_0001 to be skipped")
+	}
+
+	// A warning should have been logged.
+	if !strings.Contains(buf.String(), "permission denied") {
+		t.Errorf("expected permission denied warning in log, got: %s", buf.String())
+	}
+}
+
+func TestBuildReturnsNonPermissionError(t *testing.T) {
+	idx := New("/nonexistent-root-path-that-does-not-exist", nil)
+	if err := idx.Build(); err == nil {
+		t.Fatal("expected Build to return an error for nonexistent root")
 	}
 }
 

--- a/internal/renderer/noteext_test.go
+++ b/internal/renderer/noteext_test.go
@@ -81,7 +81,7 @@ func setupTestIndex(t *testing.T) *index.Index {
 	if err := os.WriteFile(filepath.Join(dir, "2026", "03", "20260330_9198.md"), []byte("# Note"), 0o644); err != nil {
 		t.Fatalf("write note: %v", err)
 	}
-	idx := index.New(dir)
+	idx := index.New(dir, nil)
 	idx.Build()
 	return idx
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ func NewServer(root, editor string, logger *slog.Logger) (*Server, error) {
 	if logger == nil {
 		logger = logging.Discard()
 	}
-	idx := index.New(root)
+	idx := index.New(root, logger)
 	if err := idx.Build(); err != nil {
 		return nil, fmt.Errorf("initial index build: %w", err)
 	}

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notesview/internal/logging"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -30,7 +31,7 @@ type sseClient struct {
 
 func NewSSEHub(root string, logger *slog.Logger, idx *index.Index) *SSEHub {
 	if logger == nil {
-		logger = slog.New(slog.DiscardHandler)
+		logger = logging.Discard()
 	}
 	return &SSEHub{
 		root:    root,


### PR DESCRIPTION
## Summary

- `Index.Build` now logs a warning and skips directories on permission errors, and returns non-permission errors to the caller
- `Index.Rebuild` logs errors from background builds instead of discarding them
- `Index.New` accepts a `*slog.Logger` (nil-safe, defaults to stderr)

## References

Closes #38