### PR TITLE
Fix Windows portability for editor.go

### DIFF
--- a/internal/server/editor.go
+++ b/internal/server/editor.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package server
 
 import (

--- a/internal/server/editor_windows.go
+++ b/internal/server/editor_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package server
+
+import "fmt"
+
+// openEditor is not supported on Windows. The notes viewer works fine in
+// the browser; only the "open in editor" feature requires Unix process
+// management (Setpgid) and platform-specific terminal launchers.
+func openEditor(editorBin string, args []string) error {
+	return fmt.Errorf("editor launching is not supported on Windows")
+}


### PR DESCRIPTION
## Summary

- Add `//go:build !windows` tag to `editor.go` to exclude Unix-specific code on Windows
- Add `editor_windows.go` stub that returns a clear error for unsupported editor launching
- Core notes viewing works on Windows; only the "open in editor" feature is excluded

## References

- Closes #39

## Test Plan

- [ ] `go build ./...` succeeds on default platform
- [ ] `GOOS=windows go build ./...` succeeds
- [ ] `go test ./internal/server/ -count=1` passes