### PR TITLE
Add version tracking, --version flag, and changelog

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,29 @@
+name: Auto-tag on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Bump patch version and push tag
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$LATEST" ]; then
+            NEXT="v0.1.0"
+          else
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            NEXT="v0.1.$((PATCH + 1))"
+          fi
+          git tag "$NEXT"
+          git push origin "$NEXT"
+          echo "Tagged $NEXT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Build-time version injection via `-ldflags` ([#N])
+- `--version` flag for the CLI ([#N])
+- CHANGELOG.md to track changes between releases ([#N])
+- GitHub Action to auto-tag on PR merge ([#N])
+
+[0.1.0]: https://github.com/dreikanter/notes-view/releases/tag/v0.1.0
+[#N]: https://github.com/dreikanter/notes-view/pull/N

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Added
 
-- Build-time version injection via `-ldflags` ([#N])
-- `--version` flag for the CLI ([#N])
-- CHANGELOG.md to track changes between releases ([#N])
-- GitHub Action to auto-tag on PR merge ([#N])
+- Build-time version injection via `-ldflags` ([#51])
+- `--version` flag for the CLI ([#51])
+- CHANGELOG.md to track changes between releases ([#51])
+- GitHub Action to auto-tag on PR merge ([#51])
 
 [0.1.0]: https://github.com/dreikanter/notes-view/releases/tag/v0.1.0
-[#N]: https://github.com/dreikanter/notes-view/pull/N
+[#51]: https://github.com/dreikanter/notes-view/pull/51

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 BIN := notesview
 BUILD_DIR := bin
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -X main.version=$(VERSION)
 
-.PHONY: build test lint clean assets assets-watch all
+.PHONY: build test lint clean assets assets-watch all install update
 
 all: assets build
 
 build:
-	go build -o $(BUILD_DIR)/$(BIN) ./cmd/$(BIN)
+	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BIN) ./cmd/$(BIN)
 
 test:
 	go test ./...
@@ -22,3 +24,12 @@ assets-watch:
 
 clean:
 	rm -rf $(BUILD_DIR)
+
+install:
+	go install -ldflags "$(LDFLAGS)" ./cmd/$(BIN)
+
+update:
+	git checkout main
+	git pull --tags
+	$(MAKE) install
+	@echo "Installed: $$(notesview --version)"

--- a/cmd/notesview/main.go
+++ b/cmd/notesview/main.go
@@ -3,15 +3,27 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
+
+var version = "dev"
 
 var rootCmd = &cobra.Command{
 	Use:           "notesview",
 	Short:         "Markdown notes viewer with live preview",
 	SilenceErrors: true,
 	SilenceUsage:  true,
+}
+
+func init() {
+	if version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+			version = info.Main.Version
+		}
+	}
+	rootCmd.Version = version
 }
 
 func main() {

--- a/docs/superpowers/plans/2026-04-12-version-tracking.md
+++ b/docs/superpowers/plans/2026-04-12-version-tracking.md
@@ -1,0 +1,249 @@
+# Version Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--version` flag, build-time version injection, auto-tagging GitHub Action, and CHANGELOG.md to notesview.
+
+**Architecture:** Version variable in `cmd/notesview/main.go` with `"dev"` default, overridden by `-ldflags` at build time. Cobra's built-in `--version` support handles the flag. GitHub Action auto-tags on merged PRs.
+
+**Tech Stack:** Go (cobra, runtime/debug), Make, GitHub Actions
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `cmd/notesview/main.go` | Modify | Add version variable, init(), debug import |
+| `Makefile` | Modify | Add VERSION, LDFLAGS, install, update targets |
+| `.github/workflows/tag.yml` | Create | Auto-tag on PR merge |
+| `CHANGELOG.md` | Create | Track changes between releases |
+
+---
+
+### Task 1: Add version variable and --version flag
+
+**Files:**
+- Modify: `cmd/notesview/main.go`
+
+- [ ] **Step 1: Add version variable, debug import, and init function**
+
+Replace the full contents of `cmd/notesview/main.go` with:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+var version = "dev"
+
+var rootCmd = &cobra.Command{
+	Use:           "notesview",
+	Short:         "Markdown notes viewer with live preview",
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func init() {
+	if version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+			version = info.Main.Version
+		}
+	}
+	rootCmd.Version = version
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+```
+
+- [ ] **Step 2: Verify it compiles and --version works**
+
+Run: `go run ./cmd/notesview --version`
+Expected output: `notesview version dev`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/notesview/main.go
+git commit -m "Add version variable and --version flag"
+```
+
+---
+
+### Task 2: Update Makefile with version injection
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Update Makefile**
+
+Replace the full contents of `Makefile` with:
+
+```makefile
+BIN := notesview
+BUILD_DIR := bin
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -X main.version=$(VERSION)
+
+.PHONY: build test lint clean assets assets-watch all install update
+
+all: assets build
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BIN) ./cmd/$(BIN)
+
+test:
+	go test ./...
+
+lint:
+	golangci-lint run ./...
+
+assets:
+	npx vite build
+
+assets-watch:
+	npx vite build --watch
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+install:
+	go install -ldflags "$(LDFLAGS)" ./cmd/$(BIN)
+
+update:
+	git checkout main
+	git pull --tags
+	$(MAKE) install
+	@echo "Installed: $$(notesview --version)"
+```
+
+- [ ] **Step 2: Verify build injects version**
+
+Run: `make build && bin/notesview --version`
+Expected output: `notesview version <git-hash>` (no tags exist yet, so `git describe` returns a commit hash)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "Add version injection via ldflags to Makefile"
+```
+
+---
+
+### Task 3: Add GitHub Action for auto-tagging
+
+**Files:**
+- Create: `.github/workflows/tag.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/tag.yml`:
+
+```yaml
+name: Auto-tag on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Bump patch version and push tag
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$LATEST" ]; then
+            NEXT="v0.1.0"
+          else
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            NEXT="v0.1.$((PATCH + 1))"
+          fi
+          git tag "$NEXT"
+          git push origin "$NEXT"
+          echo "Tagged $NEXT"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/tag.yml
+git commit -m "Add GitHub Action to auto-tag on PR merge"
+```
+
+---
+
+### Task 4: Add CHANGELOG.md
+
+**Files:**
+- Create: `CHANGELOG.md`
+
+- [ ] **Step 1: Create CHANGELOG.md**
+
+Create `CHANGELOG.md` at project root. The PR number placeholder `N` should be filled in after the PR is created:
+
+```markdown
+# Changelog
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Build-time version injection via `-ldflags` ([#N])
+- `--version` flag for the CLI ([#N])
+- CHANGELOG.md to track changes between releases ([#N])
+- GitHub Action to auto-tag on PR merge ([#N])
+
+[0.1.0]: https://github.com/dreikanter/notes-view/releases/tag/v0.1.0
+[#N]: https://github.com/dreikanter/notes-view/pull/N
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "Add CHANGELOG.md"
+```
+
+---
+
+### Task 5: Final verification
+
+- [ ] **Step 1: Run tests**
+
+Run: `go test ./...`
+Expected: all tests pass (no test changes, but verify nothing broke)
+
+- [ ] **Step 2: Run linter**
+
+Run: `golangci-lint run ./...`
+Expected: no new warnings
+
+- [ ] **Step 3: Verify --version without ldflags**
+
+Run: `go run ./cmd/notesview --version`
+Expected: `notesview version dev`
+
+- [ ] **Step 4: Verify --version with ldflags**
+
+Run: `make build && bin/notesview --version`
+Expected: `notesview version <git-describe-output>`

--- a/docs/superpowers/specs/2026-04-12-version-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-12-version-tracking-design.md
@@ -1,0 +1,129 @@
+# Version Tracking Design
+
+Add version tracking, `--version` flag, and changelog to notesview, matching the pattern established in notes-cli.
+
+## Version Variable & Flag
+
+Add to `cmd/notesview/main.go`:
+
+```go
+var version = "dev"
+
+func init() {
+    if version == "dev" {
+        if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+            version = info.Main.Version
+        }
+    }
+    rootCmd.Version = version
+}
+```
+
+- `version` defaults to `"dev"` for source builds without tags
+- `debug.ReadBuildInfo()` fallback covers `go install` from module cache
+- `rootCmd.Version` gives Cobra's built-in `--version` flag automatically
+- Build-time override via `-ldflags "-X main.version=..."`
+
+Output: `notesview version v0.1.0`
+
+## Makefile
+
+Update to inject version at build time:
+
+```makefile
+BIN := notesview
+BUILD_DIR := bin
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -X main.version=$(VERSION)
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BIN) ./cmd/$(BIN)
+
+install:
+	go install -ldflags "$(LDFLAGS)" ./cmd/$(BIN)
+
+update:
+	git checkout main
+	git pull --tags
+	$(MAKE) install
+	@echo "Installed: $$(notesview --version)"
+```
+
+- `VERSION` from `git describe --tags --always --dirty`, falling back to `dev`
+- `-ldflags` added to `build` target
+- New `install` and `update` targets matching notes-cli
+
+## GitHub Action: Auto-Tag on PR Merge
+
+New file `.github/workflows/tag.yml`:
+
+```yaml
+name: Auto-tag on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Bump patch version and push tag
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$LATEST" ]; then
+            NEXT="v0.1.0"
+          else
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            NEXT="v0.1.$((PATCH + 1))"
+          fi
+          git tag "$NEXT"
+          git push origin "$NEXT"
+          echo "Tagged $NEXT"
+```
+
+Identical to notes-cli. Auto-increments patch version on every merged PR.
+
+## CHANGELOG.md
+
+Keep a Changelog format at project root. Initial entry for this PR:
+
+```markdown
+# Changelog
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Build-time version injection via `-ldflags` ([#N])
+- `--version` flag for the CLI ([#N])
+- CHANGELOG.md to track changes between releases ([#N])
+- GitHub Action to auto-tag on PR merge ([#N])
+
+[0.1.0]: https://github.com/dreikanter/notes-view/releases/tag/v0.1.0
+[#N]: https://github.com/dreikanter/notes-view/pull/N
+```
+
+PR number filled in once the PR is created.
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `cmd/notesview/main.go` | Add `version` var, `init()`, `debug` import |
+| `Makefile` | Add `VERSION`, `LDFLAGS`, `install`, `update` targets |
+| `.github/workflows/tag.yml` | New file |
+| `CHANGELOG.md` | New file |
+
+## Verification
+
+- `make build && bin/notesview --version` prints version from git tag
+- `go build ./cmd/notesview && ./notesview --version` prints `notesview version dev`
+- `go run ./cmd/notesview --version` prints `notesview version dev`


### PR DESCRIPTION
## Summary

- Add `--version` flag via Cobra's built-in version support with `"dev"` default and `debug.ReadBuildInfo()` fallback
- Inject version from git tags at build time via `-ldflags` in Makefile; add `install` and `update` targets
- Add GitHub Action to auto-tag patch version on PR merge
- Add CHANGELOG.md in Keep a Changelog format

## References

- closes #41

## Test Plan

- [x] `go run ./cmd/notesview --version` prints `notesview version dev`
- [x] `make build && bin/notesview --version` prints version from git describe
- [x] `go test ./...` passes