### PR TITLE
Fix go module path and align conventions with notes-cli/notes-pub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /notesview
-/bin/
 .superpowers/
 /node_modules/
 .claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,19 @@
-BIN := notesview
-BUILD_DIR := bin
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS := -X main.version=$(VERSION)
-
 .PHONY: build test lint clean assets assets-watch all install update
+
+BINARY := notesview
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -X main.Version=$(VERSION)
 
 all: assets build
 
 build:
-	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BIN) ./cmd/$(BIN)
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/$(BINARY)
 
 test:
 	go test ./...
 
 lint:
-	golangci-lint run ./...
+	go tool golangci-lint run
 
 assets:
 	npx vite build
@@ -23,10 +22,10 @@ assets-watch:
 	npx vite build --watch
 
 clean:
-	rm -rf $(BUILD_DIR)
+	rm -f $(BINARY)
 
 install:
-	go install -ldflags "$(LDFLAGS)" ./cmd/$(BIN)
+	go install -ldflags "$(LDFLAGS)" ./cmd/$(BINARY)
 
 update:
 	git checkout main

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A local web server for browsing and previewing markdown notes with live reload.
 ## Installation
 
 ```sh
-go install github.com/dreikanter/notesview/cmd/notesview@latest
+go install github.com/dreikanter/notes-view/cmd/notesview@latest
 ```
 
 ## Usage

--- a/cmd/notesview/main.go
+++ b/cmd/notesview/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "dev"
+var Version = "dev"
 
 var rootCmd = &cobra.Command{
 	Use:           "notesview",
@@ -18,12 +18,12 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	if version == "dev" {
+	if Version == "dev" {
 		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
-			version = info.Main.Version
+			Version = info.Main.Version
 		}
 	}
-	rootCmd.Version = version
+	rootCmd.Version = Version
 }
 
 func main() {

--- a/cmd/notesview/serve.go
+++ b/cmd/notesview/serve.go
@@ -16,8 +16,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dreikanter/notesview/internal/logging"
-	"github.com/dreikanter/notesview/internal/server"
+	"github.com/dreikanter/notes-view/internal/logging"
+	"github.com/dreikanter/notes-view/internal/server"
 	"github.com/spf13/cobra"
 )
 

--- a/docs/superpowers/plans/2026-03-31-notesview.md
+++ b/docs/superpowers/plans/2026-03-31-notesview.md
@@ -56,7 +56,7 @@ notesview/
 Run:
 ```bash
 cd /Users/alex/20260331_plain-thunder
-go mod init github.com/dreikanter/notesview
+go mod init github.com/dreikanter/notes-view
 ```
 
 Expected: `go.mod` created
@@ -523,7 +523,7 @@ import (
 
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 // Frontmatter holds parsed YAML frontmatter fields.
@@ -656,7 +656,7 @@ go get github.com/yuin/goldmark
 go get github.com/yuin/goldmark-meta
 go get github.com/yuin/goldmark-highlighting/v2
 go get github.com/fsnotify/fsnotify
-go get github.com/dreikanter/notesview/internal/index
+go get github.com/dreikanter/notes-view/internal/index
 ```
 
 Wait — the index is a local package, no `go get` needed. Run:
@@ -696,7 +696,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 func setupTestIndex(t *testing.T) *index.Index {
@@ -798,7 +798,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 // noteProtoRe matches href="note://UID" in rendered HTML
@@ -1063,9 +1063,9 @@ import (
 	"io/fs"
 	"net/http"
 
-	"github.com/dreikanter/notesview/internal/index"
-	"github.com/dreikanter/notesview/internal/renderer"
-	"github.com/dreikanter/notesview/web"
+	"github.com/dreikanter/notes-view/internal/index"
+	"github.com/dreikanter/notes-view/internal/renderer"
+	"github.com/dreikanter/notes-view/web"
 )
 
 // Server is the notesview HTTP server.
@@ -1125,7 +1125,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dreikanter/notesview/internal/renderer"
+	"github.com/dreikanter/notes-view/internal/renderer"
 )
 
 // ViewResponse is the JSON response for the /view/ endpoint.
@@ -2273,7 +2273,7 @@ import (
 	"os/exec"
 	"runtime"
 
-	"github.com/dreikanter/notesview/internal/server"
+	"github.com/dreikanter/notes-view/internal/server"
 )
 
 func main() {
@@ -2434,7 +2434,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dreikanter/notesview/internal/server"
+	"github.com/dreikanter/notes-view/internal/server"
 )
 
 func TestIntegrationSmoke(t *testing.T) {

--- a/docs/superpowers/plans/2026-04-11-client-side-highlighting.md
+++ b/docs/superpowers/plans/2026-04-11-client-side-highlighting.md
@@ -433,7 +433,7 @@ import (
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer/html"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 ```
 
@@ -853,7 +853,7 @@ Expected: everything builds from scratch, no errors, `bin/notesview` exists.
 - [ ] **Step 2: Simulate `go install` from a clean state**
 
 ```bash
-(cd "$(mktemp -d)" && GOBIN="$PWD" go install github.com/dreikanter/notesview/cmd/notesview@none 2>&1 | head -5)
+(cd "$(mktemp -d)" && GOBIN="$PWD" go install github.com/dreikanter/notes-view/cmd/notesview@none 2>&1 | head -5)
 ```
 
 Expected: the `go install` command may refuse `@none` — that's fine; the point is just to sanity-check that `go build` inside the module source (which is what `go install` does under the hood) does not require Node. A more direct check:

--- a/docs/superpowers/plans/2026-04-12-independent-panels.md
+++ b/docs/superpowers/plans/2026-04-12-independent-panels.md
@@ -65,7 +65,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 func setupTestIndex(t *testing.T) *index.Index {
@@ -251,7 +251,7 @@ import (
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 // noteLinkStateKey identifies per-request state stored in parser.Context.
@@ -529,7 +529,7 @@ import (
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 var leadingH1 = regexp.MustCompile(`(?s)^\s*<h1[^>]*>\s*(.*?)\s*</h1>`)
@@ -807,8 +807,8 @@ import (
 	"html/template"
 	"io"
 
-	"github.com/dreikanter/notesview/internal/renderer"
-	"github.com/dreikanter/notesview/web"
+	"github.com/dreikanter/notes-view/internal/renderer"
+	"github.com/dreikanter/notes-view/web"
 )
 
 type Crumb struct {

--- a/docs/superpowers/specs/2026-04-11-client-side-highlighting-design.md
+++ b/docs/superpowers/specs/2026-04-11-client-side-highlighting-design.md
@@ -6,7 +6,7 @@
 
 - Code blocks render with readable, contrasted colors on the light background.
 - Highlighting complexity leaves the Go server; server emits plain `<pre><code class="language-xxx">` markup.
-- `go install github.com/dreikanter/notesview/cmd/notesview@latest` continues to work (no change to the install story).
+- `go install github.com/dreikanter/notes-view/cmd/notesview@latest` continues to work (no change to the install story).
 - Tool remains fully offline-capable — nothing is fetched at runtime.
 
 ## Non-Goals
@@ -133,7 +133,7 @@ web/
 
 ## Install and distribution
 
-Unchanged. `web/static/app.js`, `web/static/style.css`, `web/static/index.html` are committed to the repository. `go install github.com/dreikanter/notesview/cmd/notesview@latest` continues to work because `go:embed static/*` finds the files in the fetched module source. The tradeoff — minified blobs churn in git history — is the same tradeoff the project accepts today for the Tailwind-built `style.css`.
+Unchanged. `web/static/app.js`, `web/static/style.css`, `web/static/index.html` are committed to the repository. `go install github.com/dreikanter/notes-view/cmd/notesview@latest` continues to work because `go:embed static/*` finds the files in the fetched module source. The tradeoff — minified blobs churn in git history — is the same tradeoff the project accepts today for the Tailwind-built `style.css`.
 
 ## Migration order
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dreikanter/notesview
+module github.com/dreikanter/notes-view
 
 go 1.25.7
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dreikanter/notesview/internal/server"
+	"github.com/dreikanter/notes-view/internal/server"
 )
 
 func TestIntegrationSmoke(t *testing.T) {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dreikanter/notesview/internal/logging"
+	"github.com/dreikanter/notes-view/internal/logging"
 )
 
 var uidPattern = regexp.MustCompile(`^(\d{8}_\d+)`)

--- a/internal/index/tags.go
+++ b/internal/index/tags.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dreikanter/notesview/internal/logging"
+	"github.com/dreikanter/notes-view/internal/logging"
 )
 
 // TagIndex maps tag names to the relative paths of notes that carry them.

--- a/internal/renderer/noteext.go
+++ b/internal/renderer/noteext.go
@@ -17,7 +17,7 @@ import (
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 // wikiLinkParser is a goldmark InlineParser that recognizes [[UID]]

--- a/internal/renderer/noteext_test.go
+++ b/internal/renderer/noteext_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 // TestWikiLinkResolved verifies that [[UID]] syntax produces a link

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 
-	"github.com/dreikanter/notesview/internal/index"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 // leadingH1 matches the first <h1>…</h1> at the start of the document,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/dreikanter/notesview/internal/index"
-	"github.com/dreikanter/notesview/internal/logging"
-	"github.com/dreikanter/notesview/internal/renderer"
-	"github.com/dreikanter/notesview/web"
+	"github.com/dreikanter/notes-view/internal/index"
+	"github.com/dreikanter/notes-view/internal/logging"
+	"github.com/dreikanter/notes-view/internal/renderer"
+	"github.com/dreikanter/notes-view/web"
 )
 
 type Server struct {

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dreikanter/notesview/internal/index"
-	"github.com/dreikanter/notesview/internal/logging"
+	"github.com/dreikanter/notes-view/internal/index"
+	"github.com/dreikanter/notes-view/internal/logging"
 	"github.com/fsnotify/fsnotify"
 )
 

--- a/internal/server/templates.go
+++ b/internal/server/templates.go
@@ -5,8 +5,8 @@ import (
 	"html/template"
 	"io"
 
-	"github.com/dreikanter/notesview/internal/renderer"
-	"github.com/dreikanter/notesview/web"
+	"github.com/dreikanter/notes-view/internal/renderer"
+	"github.com/dreikanter/notes-view/web"
 )
 
 type IndexEntry struct {

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dreikanter/notesview/internal/renderer"
+	"github.com/dreikanter/notes-view/internal/renderer"
 )
 
 func TestLoadTemplates(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `go.mod` module path from `github.com/dreikanter/notesview` to `github.com/dreikanter/notes-view` to match the repository URL, fixing `go install ...@latest`
- Align Makefile conventions with notes-cli/notes-pub: `BINARY` variable name, build output to repo root, `go tool golangci-lint run`
- Capitalize version variable (`version` → `Version`) to match notes-pub pattern

## References

Closes #59