### PR TITLE
Fix missing styles after Firefox tab restore

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -97,3 +97,27 @@ func logRequests(logger *slog.Logger) func(http.Handler) http.Handler {
 func isNoisyPath(path string) bool {
 	return strings.HasPrefix(path, "/static/")
 }
+
+// setHXCacheHeaders annotates responses so caches never serve an HTMX
+// partial in place of a full-page navigation at the same URL.
+//
+// Several routes (/view/..., /dir/..., /tags, /tags/{tag}) return the
+// full layout for a top-level GET but a bare fragment when HTMX asks
+// for an in-page swap. Without Vary, any URL-keyed cache treats those
+// two bodies as interchangeable — Firefox restoring a closed tab with
+// Cmd+Shift+T then replays the partial as a document and the page
+// renders with no <head> and no stylesheet.
+//
+// Vary: HX-Request, HX-Target teaches conforming HTTP caches that the
+// response is per-header. Cache-Control: no-store on the partial
+// additionally keeps it out of Firefox's session store, which replays
+// response bodies on tab restore and does not honor Vary.
+func setHXCacheHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Vary", "HX-Request, HX-Target")
+		if r.Header.Get("HX-Request") == "true" {
+			w.Header().Set("Cache-Control", "no-store")
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -118,6 +118,51 @@ func TestLogRequestsDemotesStaticAssets(t *testing.T) {
 	}
 }
 
+// TestSetHXCacheHeadersTopLevel verifies a plain top-level GET gets
+// Vary: HX-Request, HX-Target so a URL-keyed cache won't later serve
+// this full-page response as a partial (or vice versa). No-store
+// should NOT be set on top-level responses — they're genuinely
+// cacheable.
+func TestSetHXCacheHeadersTopLevel(t *testing.T) {
+	handler := setHXCacheHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/view/foo.md", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Vary"); got != "HX-Request, HX-Target" {
+		t.Errorf("Vary = %q, want %q", got, "HX-Request, HX-Target")
+	}
+	if got := w.Header().Get("Cache-Control"); got != "" {
+		t.Errorf("Cache-Control on top-level = %q, want empty", got)
+	}
+}
+
+// TestSetHXCacheHeadersPartial verifies an HTMX partial response
+// carries both Vary and Cache-Control: no-store, so it stays out of
+// the HTTP cache AND out of Firefox's session store (which replays
+// bodies on tab restore without honoring Vary).
+func TestSetHXCacheHeadersPartial(t *testing.T) {
+	handler := setHXCacheHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/view/foo.md", nil)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Target", "note-pane")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Vary"); got != "HX-Request, HX-Target" {
+		t.Errorf("Vary = %q, want %q", got, "HX-Request, HX-Target")
+	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+}
+
 func TestLogResponseWriterFlushPassesThrough(t *testing.T) {
 	// The wrapped writer must still expose http.Flusher so SSE keeps
 	// working. httptest.NewRecorder implements Flusher, so we can assert

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,7 +75,7 @@ func (s *Server) Routes() http.Handler {
 		mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 	}
 
-	return logRequests(s.logger)(rejectDirtyPaths(mux))
+	return logRequests(s.logger)(rejectDirtyPaths(setHXCacheHeaders(mux)))
 }
 
 // rejectDirtyPaths returns 400 for any request whose raw URL path is not


### PR DESCRIPTION
## Summary

- Server routes return a full page for top-level GETs but a bare fragment for HTMX swaps at the same URL. Without `Vary`, a URL-keyed cache treats them as interchangeable, so Firefox's `Cmd+Shift+T` tab restore can replay the partial as a document — the page renders with no `<head>` and no stylesheet.
- New `setHXCacheHeaders` middleware sets `Vary: HX-Request, HX-Target` on every response and `Cache-Control: no-store` on partials (Firefox's session store replays bodies on tab restore and does not honor `Vary`).
- Unit tests cover both header contracts.

## Test plan

- [x] `go test ./...`
- [x] `curl -I /view/X` → `Vary: HX-Request, HX-Target`, no `Cache-Control`
- [x] `curl -I -H "HX-Request: true" -H "HX-Target: note-pane" /view/X` → `Vary: HX-Request, HX-Target`, `Cache-Control: no-store`
- [x] Firefox manual: open note, close tab, `Cmd+Shift+T` → styles applied

## References

- closes #63