### PR TITLE
Drop renderer.Frontmatter in favor of NoteEntry

### DIFF
--- a/internal/index/frontmatter.go
+++ b/internal/index/frontmatter.go
@@ -21,11 +21,12 @@ func isFenceLine(line string) bool {
 // given file default to Go zero values. The struct is intentionally
 // private: extending it with new fields is a local change.
 type frontmatter struct {
-	Title   string    `yaml:"title"`
-	Slug    string    `yaml:"slug"`
-	Tags    []string  `yaml:"tags"`
-	Aliases []string  `yaml:"aliases"`
-	Date    time.Time `yaml:"date"`
+	Title       string    `yaml:"title"`
+	Slug        string    `yaml:"slug"`
+	Description string    `yaml:"description"`
+	Tags        []string  `yaml:"tags"`
+	Aliases     []string  `yaml:"aliases"`
+	Date        time.Time `yaml:"date"`
 }
 
 // parseFrontmatter reads the file at path, extracts the YAML block between

--- a/internal/index/note_index.go
+++ b/internal/index/note_index.go
@@ -31,15 +31,16 @@ func IsUID(s string) bool {
 // needed for today's lookups are populated for future derived maps
 // (bySlug, byAlias, byDate) without requiring a second walk.
 type NoteEntry struct {
-	RelPath    string
-	UID        string
-	Stem       string
-	Slug       string
-	Title      string
-	Tags       []string
-	Aliases    []string
-	Date       time.Time
-	DateSource string
+	RelPath     string
+	UID         string
+	Stem        string
+	Slug        string
+	Title       string
+	Description string
+	Tags        []string
+	Aliases     []string
+	Date        time.Time
+	DateSource  string
 }
 
 // NoteIndex is the unified in-memory index of the notes tree. It is safe
@@ -51,6 +52,7 @@ type NoteIndex struct {
 	mu       sync.RWMutex
 	entries  []NoteEntry
 	byUID    map[string]string
+	byRel    map[string]int
 	byTag    map[string][]string
 	allTags  []string
 	building sync.Mutex
@@ -66,6 +68,7 @@ func New(root string, logger *slog.Logger) *NoteIndex {
 		root:   root,
 		logger: logger,
 		byUID:  make(map[string]string),
+		byRel:  make(map[string]int),
 		byTag:  make(map[string][]string),
 	}
 }
@@ -76,6 +79,7 @@ func New(root string, logger *slog.Logger) *NoteIndex {
 func (i *NoteIndex) Build() error {
 	var entries []NoteEntry
 	byUID := make(map[string]string)
+	byRel := make(map[string]int)
 	byTag := make(map[string][]string)
 
 	err := filepath.WalkDir(i.root, func(path string, d os.DirEntry, err error) error {
@@ -120,16 +124,18 @@ func (i *NoteIndex) Build() error {
 		date, source := resolveDate(uid, fm.Date, info)
 
 		entry := NoteEntry{
-			RelPath:    rel,
-			UID:        uid,
-			Stem:       stem,
-			Slug:       deriveSlug(stem, uid, fm.Slug),
-			Title:      fm.Title,
-			Tags:       tags,
-			Aliases:    append([]string(nil), fm.Aliases...),
-			Date:       date,
-			DateSource: source,
+			RelPath:     rel,
+			UID:         uid,
+			Stem:        stem,
+			Slug:        deriveSlug(stem, uid, fm.Slug),
+			Title:       fm.Title,
+			Description: fm.Description,
+			Tags:        tags,
+			Aliases:     append([]string(nil), fm.Aliases...),
+			Date:        date,
+			DateSource:  source,
 		}
+		byRel[rel] = len(entries)
 		entries = append(entries, entry)
 
 		if uid != "" {
@@ -156,6 +162,7 @@ func (i *NoteIndex) Build() error {
 	i.mu.Lock()
 	i.entries = entries
 	i.byUID = byUID
+	i.byRel = byRel
 	i.byTag = byTag
 	i.allTags = allTags
 	i.mu.Unlock()
@@ -183,6 +190,18 @@ func (i *NoteIndex) NoteByUID(uid string) (string, bool) {
 	defer i.mu.RUnlock()
 	p, ok := i.byUID[uid]
 	return p, ok
+}
+
+// NoteEntryByRel returns the NoteEntry whose RelPath equals rel (expected
+// in forward-slash form) and a found flag.
+func (i *NoteIndex) NoteEntryByRel(rel string) (NoteEntry, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	idx, ok := i.byRel[rel]
+	if !ok {
+		return NoteEntry{}, false
+	}
+	return i.entries[idx], true
 }
 
 // Tags returns a copy of the sorted, deduplicated tag list.

--- a/internal/index/note_index.go
+++ b/internal/index/note_index.go
@@ -193,7 +193,9 @@ func (i *NoteIndex) NoteByUID(uid string) (string, bool) {
 }
 
 // NoteEntryByRel returns the NoteEntry whose RelPath equals rel (expected
-// in forward-slash form) and a found flag.
+// in forward-slash form) and a found flag. Slice fields (Tags, Aliases)
+// are defensively copied so callers cannot mutate the index's internal
+// storage — matching the convention used by Tags and NotesByTag.
 func (i *NoteIndex) NoteEntryByRel(rel string) (NoteEntry, bool) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
@@ -201,7 +203,10 @@ func (i *NoteIndex) NoteEntryByRel(rel string) (NoteEntry, bool) {
 	if !ok {
 		return NoteEntry{}, false
 	}
-	return i.entries[idx], true
+	entry := i.entries[idx]
+	entry.Tags = append([]string(nil), entry.Tags...)
+	entry.Aliases = append([]string(nil), entry.Aliases...)
+	return entry, true
 }
 
 // Tags returns a copy of the sorted, deduplicated tag list.

--- a/internal/index/note_index_test.go
+++ b/internal/index/note_index_test.go
@@ -431,6 +431,35 @@ func TestNoteEntryByRel(t *testing.T) {
 	}
 }
 
+// TestNoteEntryByRelReturnsDefensiveCopy pins that mutating the returned
+// entry's slice fields does not corrupt internal storage. Matches the
+// defensive-copy convention used by Tags and NotesByTag.
+func TestNoteEntryByRelReturnsDefensiveCopy(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "note.md"),
+		"---\ntags: [a, b]\naliases: [x, y]\n---\n")
+
+	idx := New(dir, nil)
+	if err := idx.Build(); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	first, ok := idx.NoteEntryByRel("note.md")
+	if !ok {
+		t.Fatal("NoteEntryByRel = !ok, want ok")
+	}
+	first.Tags[0] = "MUTATED"
+	first.Aliases[0] = "MUTATED"
+
+	second, _ := idx.NoteEntryByRel("note.md")
+	if second.Tags[0] != "a" {
+		t.Errorf("Tags[0] = %q, want %q (caller mutation leaked into index)", second.Tags[0], "a")
+	}
+	if second.Aliases[0] != "x" {
+		t.Errorf("Aliases[0] = %q, want %q (caller mutation leaked into index)", second.Aliases[0], "x")
+	}
+}
+
 func TestNoteEntryAliases(t *testing.T) {
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "inline.md"),

--- a/internal/index/note_index_test.go
+++ b/internal/index/note_index_test.go
@@ -385,6 +385,52 @@ func TestNoteEntryTitle(t *testing.T) {
 	}
 }
 
+func TestNoteEntryDescription(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "a.md"),
+		"---\ndescription: A short summary\n---\n")
+	mustWriteFile(t, filepath.Join(dir, "b.md"), "# No frontmatter\n")
+
+	idx := New(dir, nil)
+	if err := idx.Build(); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := entryByRel(t, idx, "a.md").Description; got != "A short summary" {
+		t.Errorf("Description = %q, want %q", got, "A short summary")
+	}
+	if got := entryByRel(t, idx, "b.md").Description; got != "" {
+		t.Errorf("Description = %q, want empty", got)
+	}
+}
+
+func TestNoteEntryByRel(t *testing.T) {
+	dir := t.TempDir()
+	mustMkdirAll(t, filepath.Join(dir, "sub"))
+	mustWriteFile(t, filepath.Join(dir, "sub", "note.md"),
+		"---\ntitle: Nested\n---\n")
+	mustWriteFile(t, filepath.Join(dir, "root.md"), "# Root\n")
+
+	idx := New(dir, nil)
+	if err := idx.Build(); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	got, ok := idx.NoteEntryByRel("sub/note.md")
+	if !ok {
+		t.Fatal("NoteEntryByRel(sub/note.md) = !ok, want ok")
+	}
+	if got.Title != "Nested" {
+		t.Errorf("Title = %q, want Nested", got.Title)
+	}
+
+	if _, ok := idx.NoteEntryByRel("root.md"); !ok {
+		t.Error("NoteEntryByRel(root.md) = !ok, want ok")
+	}
+	if _, ok := idx.NoteEntryByRel("missing.md"); ok {
+		t.Error("NoteEntryByRel(missing.md) = ok, want !ok")
+	}
+}
+
 func TestNoteEntryAliases(t *testing.T) {
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "inline.md"),

--- a/internal/renderer/highlighting_test.go
+++ b/internal/renderer/highlighting_test.go
@@ -8,7 +8,7 @@ import (
 func TestRenderFencedCodeBlockEmitsLanguageClass(t *testing.T) {
 	r := NewRenderer(nil)
 	src := []byte("```go\nfunc foo() {}\n```\n")
-	out, _, err := r.Render(src, "")
+	out, err := r.Render(src, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -23,7 +23,7 @@ func TestRenderFencedCodeBlockEmitsLanguageClass(t *testing.T) {
 func TestRenderFencedCodeBlockWithoutLanguage(t *testing.T) {
 	r := NewRenderer(nil)
 	src := []byte("```\nplain text\n```\n")
-	out, _, err := r.Render(src, "")
+	out, err := r.Render(src, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -37,29 +37,11 @@ func TestRenderFencedCodeBlockWithoutLanguage(t *testing.T) {
 func TestRenderEscapesRawHTML(t *testing.T) {
 	r := NewRenderer(nil)
 	src := []byte("Hello\n\n<script>alert('xss')</script>\n")
-	out, _, err := r.Render(src, "")
+	out, err := r.Render(src, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	if strings.Contains(out, "<script>") {
 		t.Errorf("expected raw <script> to be escaped, got:\n%s", out)
-	}
-}
-
-// TestStripRedundantTitleHandlesEntities covers titles that contain HTML
-// entities once rendered (e.g. "A & B" becomes "A &amp; B"), making sure
-// the strip-on-match check still fires.
-func TestStripRedundantTitleHandlesEntities(t *testing.T) {
-	r := NewRenderer(nil)
-	src := []byte("---\ntitle: A & B\n---\n# A & B\n\nbody\n")
-	out, fm, err := r.Render(src, "")
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
-	if fm == nil || fm.Title != "A & B" {
-		t.Fatalf("frontmatter title = %v, want %q", fm, "A & B")
-	}
-	if strings.Contains(out, "<h1") {
-		t.Errorf("expected leading <h1> to be stripped when it matches title, got:\n%s", out)
 	}
 }

--- a/internal/renderer/noteext_test.go
+++ b/internal/renderer/noteext_test.go
@@ -14,7 +14,7 @@ import (
 func TestWikiLinkResolved(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
-	html, _, err := r.Render([]byte(`See [[20260331_9201]] for details.`), "")
+	html, err := r.Render([]byte(`See [[20260331_9201]] for details.`), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func TestWikiLinkResolved(t *testing.T) {
 func TestWikiLinkUnresolved(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
-	html, _, err := r.Render([]byte(`See [[99999999_0000]] here.`), "")
+	html, err := r.Render([]byte(`See [[99999999_0000]] here.`), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestWikiLinkUnresolved(t *testing.T) {
 func TestWikiLinkInvalidPattern(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
-	html, _, err := r.Render([]byte(`See [[hello_world]] here.`), "")
+	html, err := r.Render([]byte(`See [[hello_world]] here.`), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func setupTestIndex(t *testing.T) *index.NoteIndex {
 func TestNoteProtocolLink(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
-	html, _, err := r.Render([]byte(`See [my todo](note://20260331_9201) for details.`), "")
+	html, err := r.Render([]byte(`See [my todo](note://20260331_9201) for details.`), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestNoteProtocolLink(t *testing.T) {
 func TestBrokenNoteLink(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
-	html, _, err := r.Render([]byte(`See [missing](note://99999999_0000) link.`), "")
+	html, err := r.Render([]byte(`See [missing](note://99999999_0000) link.`), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestBrokenNoteLink(t *testing.T) {
 func TestRelativeMdLink(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
-	html, _, err := r.Render([]byte(`See [other](../01/foo.md) for details.`), "2026/03")
+	html, err := r.Render([]byte(`See [other](../01/foo.md) for details.`), "2026/03")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestExternalLinksStayPlain(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
 	input := `[web](https://example.com) [mail](mailto:a@b.com) [asset](/static/foo.png)`
-	html, _, err := r.Render([]byte(input), "")
+	html, err := r.Render([]byte(input), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestDangerousURLsSanitized(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
 	input := `[xss](javascript:alert(1)) [vb](vbscript:msgbox) [f](file:///etc/passwd) [d](data:text/html,<script>alert(1)</script>)`
-	html, _, err := r.Render([]byte(input), "")
+	html, err := r.Render([]byte(input), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestDangerousURLsSanitized(t *testing.T) {
 	}
 	// An image data URL is allowed (links may legitimately point at
 	// base64 images in rare cases).
-	html2, _, err := r.Render([]byte(`[ok](data:image/png;base64,iVBORw0K)`), "")
+	html2, err := r.Render([]byte(`[ok](data:image/png;base64,iVBORw0K)`), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestInternalLinksNoDirQuery(t *testing.T) {
 	idx := setupTestIndex(t)
 	r := NewRenderer(idx)
 	input := `See [todo](note://20260331_9201), [rel](../03/20260330_9198.md), and [[20260331_9201]].`
-	html, _, err := r.Render([]byte(input), "2026/03")
+	html, err := r.Render([]byte(input), "2026/03")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -22,13 +22,6 @@ var leadingH1 = regexp.MustCompile(`(?s)^\s*<h1[^>]*>\s*(.*?)\s*</h1>`)
 // can compare it against a plain frontmatter title.
 var tagStripper = regexp.MustCompile(`<[^>]+>`)
 
-type Frontmatter struct {
-	Title       string   `yaml:"title"`
-	Tags        []string `yaml:"tags"`
-	Description string   `yaml:"description"`
-	Slug        string   `yaml:"slug"`
-}
-
 type Renderer struct {
 	md    goldmark.Markdown
 	index *index.NoteIndex
@@ -55,7 +48,10 @@ func NewRenderer(idx *index.NoteIndex) *Renderer {
 
 // Render converts markdown to HTML. currentDir is the note's parent
 // directory relative to the notes root (used to resolve `[text](./rel.md)`).
-func (r *Renderer) Render(source []byte, currentDir string) (string, *Frontmatter, error) {
+// Frontmatter is consumed by goldmark-meta (so its YAML fence does not
+// render as content), but this method does not return it — the index is
+// the single source of truth for note metadata.
+func (r *Renderer) Render(source []byte, currentDir string) (string, error) {
 	ctx := parser.NewContext()
 	if r.index != nil {
 		ctx.Set(noteLinkStateKey, &noteLinkState{
@@ -66,37 +62,22 @@ func (r *Renderer) Render(source []byte, currentDir string) (string, *Frontmatte
 
 	var buf bytes.Buffer
 	if err := r.md.Convert(source, &buf, parser.WithContext(ctx)); err != nil {
-		return "", nil, err
-	}
-
-	var fm *Frontmatter
-	metaData := meta.Get(ctx)
-	if metaData != nil {
-		fm = &Frontmatter{}
-		if t, ok := metaData["title"].(string); ok {
-			fm.Title = t
-		}
-		if d, ok := metaData["description"].(string); ok {
-			fm.Description = d
-		}
-		if s, ok := metaData["slug"].(string); ok {
-			fm.Slug = s
-		}
-		if tags, ok := metaData["tags"].([]interface{}); ok {
-			for _, tag := range tags {
-				if s, ok := tag.(string); ok {
-					fm.Tags = append(fm.Tags, s)
-				}
-			}
-		}
+		return "", err
 	}
 
 	html := buf.String()
 	html = processTaskSyntax(html)
-	if fm != nil && fm.Title != "" {
-		html = stripRedundantTitle(html, fm.Title)
+	return html, nil
+}
+
+// StripRedundantTitle removes a leading <h1>X</h1> from html when its
+// plain-text content equals title. Returns html unchanged when title is
+// empty or no match is found.
+func StripRedundantTitle(html, title string) string {
+	if title == "" {
+		return html
 	}
-	return html, fm, nil
+	return stripRedundantTitle(html, title)
 }
 
 // stripRedundantTitle removes a leading <h1> whose plain-text content equals

--- a/internal/renderer/renderer_test.go
+++ b/internal/renderer/renderer_test.go
@@ -5,153 +5,43 @@ import (
 	"testing"
 )
 
-func TestFrontmatterMissing(t *testing.T) {
+func TestRenderBasicMarkdown(t *testing.T) {
 	r := NewRenderer(nil)
-	html, fm, err := r.Render([]byte("# Hello\n\nSome text."), "")
+	html, err := r.Render([]byte("# Hello\n\nSome text."), "")
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
-	}
-	if fm != nil {
-		t.Errorf("expected nil frontmatter, got %+v", fm)
 	}
 	if !strings.Contains(html, "Hello") {
 		t.Errorf("expected HTML to contain heading, got: %s", html)
 	}
+	if !strings.Contains(html, "Some text") {
+		t.Errorf("expected HTML to contain body, got: %s", html)
+	}
 }
 
-func TestFrontmatterEmpty(t *testing.T) {
+// TestRenderSkipsFrontmatter pins that goldmark-meta still consumes the
+// leading `---…---` fence so it is not rendered as content. We do not
+// read the metadata — that is the index's job — but the fence must not
+// leak into the HTML as an <hr> or plain text.
+func TestRenderSkipsFrontmatter(t *testing.T) {
 	r := NewRenderer(nil)
-	html, fm, err := r.Render([]byte("---\n---\n# Hello"), "")
+	html, err := r.Render([]byte("---\ntitle: My Note\n---\n# Hello\n\nBody."), "")
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
 	}
-	if fm == nil {
-		t.Fatal("expected non-nil frontmatter for empty YAML block")
-	}
-	if fm.Title != "" || fm.Description != "" || fm.Slug != "" || len(fm.Tags) != 0 {
-		t.Errorf("expected all fields empty, got %+v", fm)
+	if strings.Contains(html, "title: My Note") {
+		t.Errorf("frontmatter YAML leaked into HTML: %s", html)
 	}
 	if !strings.Contains(html, "Hello") {
-		t.Errorf("expected HTML to contain heading, got: %s", html)
+		t.Errorf("expected body content in HTML: %s", html)
 	}
 }
 
-func TestFrontmatterTitleOnly(t *testing.T) {
+func TestRenderEmptyDocument(t *testing.T) {
 	r := NewRenderer(nil)
-	_, fm, err := r.Render([]byte("---\ntitle: My Note\n---\nBody."), "")
+	html, err := r.Render([]byte(""), "")
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
-	}
-	if fm == nil {
-		t.Fatal("expected non-nil frontmatter")
-	}
-	if fm.Title != "My Note" {
-		t.Errorf("title = %q, want %q", fm.Title, "My Note")
-	}
-	if fm.Description != "" || fm.Slug != "" || len(fm.Tags) != 0 {
-		t.Errorf("expected other fields empty, got %+v", fm)
-	}
-}
-
-func TestFrontmatterTagsOnly(t *testing.T) {
-	r := NewRenderer(nil)
-	_, fm, err := r.Render([]byte("---\ntags:\n  - go\n  - testing\n---\nBody."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if fm == nil {
-		t.Fatal("expected non-nil frontmatter")
-	}
-	if fm.Title != "" {
-		t.Errorf("title should be empty, got %q", fm.Title)
-	}
-	if len(fm.Tags) != 2 || fm.Tags[0] != "go" || fm.Tags[1] != "testing" {
-		t.Errorf("tags = %v, want [go testing]", fm.Tags)
-	}
-}
-
-func TestFrontmatterAllFields(t *testing.T) {
-	r := NewRenderer(nil)
-	input := "---\ntitle: Full\ndescription: A note\nslug: full-note\ntags:\n  - a\n  - b\n---\nBody."
-	_, fm, err := r.Render([]byte(input), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if fm == nil {
-		t.Fatal("expected non-nil frontmatter")
-	}
-	if fm.Title != "Full" {
-		t.Errorf("title = %q, want %q", fm.Title, "Full")
-	}
-	if fm.Description != "A note" {
-		t.Errorf("description = %q, want %q", fm.Description, "A note")
-	}
-	if fm.Slug != "full-note" {
-		t.Errorf("slug = %q, want %q", fm.Slug, "full-note")
-	}
-	if len(fm.Tags) != 2 || fm.Tags[0] != "a" || fm.Tags[1] != "b" {
-		t.Errorf("tags = %v, want [a b]", fm.Tags)
-	}
-}
-
-func TestFrontmatterMalformedYAML(t *testing.T) {
-	r := NewRenderer(nil)
-	// Scalar value instead of a mapping — goldmark-meta returns nil
-	// because it expects a YAML map.
-	_, fm, err := r.Render([]byte("---\njust a string\n---\nBody."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if fm != nil {
-		t.Errorf("expected nil frontmatter for non-mapping YAML, got %+v", fm)
-	}
-	_ = r
-}
-
-func TestFrontmatterUnknownKeys(t *testing.T) {
-	r := NewRenderer(nil)
-	// Valid YAML mapping but with keys we don't recognize — fm is
-	// non-nil but all known fields should be zero-valued.
-	_, fm, err := r.Render([]byte("---\nauthor: Jane\nrating: 5\n---\nBody."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if fm == nil {
-		t.Fatal("expected non-nil frontmatter for valid YAML mapping")
-	}
-	if fm.Title != "" || fm.Description != "" || fm.Slug != "" || len(fm.Tags) != 0 {
-		t.Errorf("expected all known fields empty, got %+v", fm)
-	}
-	_ = r
-}
-
-func TestFrontmatterWrongTypes(t *testing.T) {
-	r := NewRenderer(nil)
-	// title is a list, tags is a string — wrong types for our mapping.
-	input := "---\ntitle:\n  - not\n  - a string\ntags: just-a-string\n---\nBody."
-	_, fm, err := r.Render([]byte(input), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if fm == nil {
-		t.Fatal("expected non-nil frontmatter")
-	}
-	if fm.Title != "" {
-		t.Errorf("title should be empty for non-string value, got %q", fm.Title)
-	}
-	if len(fm.Tags) != 0 {
-		t.Errorf("tags should be empty for non-list value, got %v", fm.Tags)
-	}
-}
-
-func TestEmptyDocument(t *testing.T) {
-	r := NewRenderer(nil)
-	html, fm, err := r.Render([]byte(""), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if fm != nil {
-		t.Errorf("expected nil frontmatter for empty input, got %+v", fm)
 	}
 	if html != "" {
 		t.Errorf("expected empty HTML for empty input, got %q", html)
@@ -160,11 +50,11 @@ func TestEmptyDocument(t *testing.T) {
 
 func TestStripRedundantTitleExact(t *testing.T) {
 	r := NewRenderer(nil)
-	input := "---\ntitle: Hello World\n---\n# Hello World\n\nBody text."
-	html, _, err := r.Render([]byte(input), "")
+	html, err := r.Render([]byte("# Hello World\n\nBody text."), "")
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
 	}
+	html = StripRedundantTitle(html, "Hello World")
 	if strings.Contains(html, "<h1") {
 		t.Errorf("redundant <h1> should be stripped, got: %s", html)
 	}
@@ -176,12 +66,12 @@ func TestStripRedundantTitleExact(t *testing.T) {
 func TestStripRedundantTitleHTMLEntities(t *testing.T) {
 	r := NewRenderer(nil)
 	// Goldmark renders "A & B" in a heading as "A &amp; B".
-	// stripRedundantTitle should decode entities before comparing.
-	input := "---\ntitle: A & B\n---\n# A & B\n\nBody."
-	html, _, err := r.Render([]byte(input), "")
+	// StripRedundantTitle should decode entities before comparing.
+	html, err := r.Render([]byte("# A & B\n\nBody."), "")
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
 	}
+	html = StripRedundantTitle(html, "A & B")
 	if strings.Contains(html, "<h1") {
 		t.Errorf("h1 with HTML entities should be stripped when matching title, got: %s", html)
 	}
@@ -191,11 +81,11 @@ func TestStripRedundantTitleInlineMarkup(t *testing.T) {
 	r := NewRenderer(nil)
 	// "# **Bold** title" renders as <h1><strong>Bold</strong> title</h1>.
 	// After stripping inner tags, the plain text is "Bold title".
-	input := "---\ntitle: Bold title\n---\n# **Bold** title\n\nBody."
-	html, _, err := r.Render([]byte(input), "")
+	html, err := r.Render([]byte("# **Bold** title\n\nBody."), "")
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
 	}
+	html = StripRedundantTitle(html, "Bold title")
 	if strings.Contains(html, "<h1") {
 		t.Errorf("h1 with inline markup should be stripped when plain text matches title, got: %s", html)
 	}
@@ -203,12 +93,11 @@ func TestStripRedundantTitleInlineMarkup(t *testing.T) {
 
 func TestStripRedundantTitleMismatch(t *testing.T) {
 	r := NewRenderer(nil)
-	// When the h1 content doesn't match the frontmatter title, keep it.
-	input := "---\ntitle: Actual Title\n---\n# Different Heading\n\nBody."
-	html, _, err := r.Render([]byte(input), "")
+	html, err := r.Render([]byte("# Different Heading\n\nBody."), "")
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
 	}
+	html = StripRedundantTitle(html, "Actual Title")
 	if !strings.Contains(html, "<h1") {
 		t.Errorf("non-matching h1 should be preserved, got: %s", html)
 	}
@@ -219,7 +108,7 @@ func TestStripRedundantTitleMismatch(t *testing.T) {
 
 func TestStripRedundantTitleLeadingWhitespace(t *testing.T) {
 	// The leadingH1 regex tolerates leading whitespace before <h1>.
-	got := stripRedundantTitle("  \n<h1>Hello</h1>\n<p>Body</p>", "Hello")
+	got := StripRedundantTitle("  \n<h1>Hello</h1>\n<p>Body</p>", "Hello")
 	if strings.Contains(got, "<h1") {
 		t.Errorf("leading whitespace before h1 should still match, got: %s", got)
 	}
@@ -230,26 +119,22 @@ func TestStripRedundantTitleLeadingWhitespace(t *testing.T) {
 
 func TestStripRedundantTitleNoH1(t *testing.T) {
 	r := NewRenderer(nil)
-	// Document with a title in frontmatter but no h1 in the body.
-	input := "---\ntitle: My Title\n---\n## Subtitle\n\nBody."
-	html, _, err := r.Render([]byte(input), "")
+	html, err := r.Render([]byte("## Subtitle\n\nBody."), "")
 	if err != nil {
 		t.Fatalf("Render failed: %v", err)
 	}
+	html = StripRedundantTitle(html, "My Title")
 	if !strings.Contains(html, "Subtitle") {
 		t.Errorf("h2 should be preserved, got: %s", html)
 	}
 }
 
-func TestStripRedundantTitleNoFrontmatterTitle(t *testing.T) {
-	r := NewRenderer(nil)
-	// Frontmatter exists but has no title — h1 should be preserved.
-	input := "---\ntags:\n  - go\n---\n# Keep This\n\nBody."
-	html, _, err := r.Render([]byte(input), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
+func TestStripRedundantTitleEmptyTitle(t *testing.T) {
+	// An empty title must be a no-op even if the document starts with an
+	// <h1> — otherwise a misconfigured caller could accidentally strip
+	// legitimate headings.
+	html := StripRedundantTitle("<h1>Keep This</h1><p>Body</p>", "")
 	if !strings.Contains(html, "<h1") {
-		t.Errorf("h1 should be preserved when frontmatter has no title, got: %s", html)
+		t.Errorf("empty title should leave h1 intact, got: %s", html)
 	}
 }

--- a/internal/renderer/tasks_test.go
+++ b/internal/renderer/tasks_test.go
@@ -36,7 +36,7 @@ func TestTaskSyntax(t *testing.T) {
 	r := NewRenderer(nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			html, _, err := r.Render([]byte(tt.input), "")
+			html, err := r.Render([]byte(tt.input), "")
 			if err != nil {
 				t.Fatalf("Render failed: %v", err)
 			}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/dreikanter/notes-view/internal/index"
+	"github.com/dreikanter/notes-view/internal/renderer"
 )
 
 // buildLayoutFields assembles the common chrome every full-page render needs.
@@ -111,15 +114,21 @@ func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
 
 	currentDir := noteParentDir(reqPath)
 
-	html, fm, err := s.renderer.Render(data, currentDir)
+	html, err := s.renderer.Render(data, currentDir)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	var note *index.NoteEntry
+	if entry, ok := s.index.NoteEntryByRel(reqPath); ok {
+		note = &entry
+	}
+
 	title := filepath.Base(reqPath)
-	if fm != nil && fm.Title != "" {
-		title = fm.Title
+	if note != nil && note.Title != "" {
+		title = note.Title
+		html = renderer.StripRedundantTitle(html, note.Title)
 	}
 	noteTitle := title
 
@@ -133,14 +142,14 @@ func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
 	// Note-pane partial response: return only the note body, no chrome.
 	if hxTargetedAt(r, "note-pane") {
 		partial := NotePartialData{
-			NotePath:    reqPath,
-			NoteTitle:   noteTitle,
-			Frontmatter: fm,
-			HTML:        template.HTML(html),
-			SSEWatch:    viewSSEWatch(reqPath),
-			ViewHref:    "/view/" + viewPath(reqPath),
-			EditPath:    editPath,
-			EditHref:    eHref,
+			NotePath:  reqPath,
+			NoteTitle: noteTitle,
+			Note:      note,
+			HTML:      template.HTML(html),
+			SSEWatch:  viewSSEWatch(reqPath),
+			ViewHref:  "/view/" + viewPath(reqPath),
+			EditPath:  editPath,
+			EditHref:  eHref,
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if err := s.templates.renderNotePartial(w, partial); err != nil {
@@ -164,7 +173,7 @@ func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
 		layoutFields: lf,
 		NotePath:     reqPath,
 		NoteTitle:    noteTitle,
-		Frontmatter:  fm,
+		Note:         note,
 		HTML:         template.HTML(html),
 		SSEWatch:     viewSSEWatch(reqPath),
 		ViewHref:     "/view/" + viewPath(reqPath),

--- a/internal/server/templates.go
+++ b/internal/server/templates.go
@@ -5,7 +5,7 @@ import (
 	"html/template"
 	"io"
 
-	"github.com/dreikanter/notes-view/internal/renderer"
+	"github.com/dreikanter/notes-view/internal/index"
 	"github.com/dreikanter/notes-view/web"
 )
 
@@ -34,28 +34,28 @@ type layoutFields struct {
 // ViewData is the full-page render context for a note view.
 type ViewData struct {
 	layoutFields
-	NotePath    string
-	NoteTitle   string
-	Frontmatter *renderer.Frontmatter
-	HTML        template.HTML
-	SSEWatch    string
-	ViewHref    string
-	Sidebar     SidebarPartialData
-	DirListing  *DirListingData // non-nil when main panel shows a directory listing
+	NotePath   string
+	NoteTitle  string
+	Note       *index.NoteEntry
+	HTML       template.HTML
+	SSEWatch   string
+	ViewHref   string
+	Sidebar    SidebarPartialData
+	DirListing *DirListingData // non-nil when main panel shows a directory listing
 }
 
 // NotePartialData is the render context for an HX-Target: note-pane
 // partial response. Only the fields the note-pane template needs;
 // no sidebar, no topbar.
 type NotePartialData struct {
-	NotePath    string
-	NoteTitle   string
-	Frontmatter *renderer.Frontmatter
-	HTML        template.HTML
-	SSEWatch    string
-	ViewHref    string
-	EditPath    string
-	EditHref    string
+	NotePath  string
+	NoteTitle string
+	Note      *index.NoteEntry
+	HTML      template.HTML
+	SSEWatch  string
+	ViewHref  string
+	EditPath  string
+	EditHref  string
 }
 
 // SidebarPartialData is the render context for the sidebar tree.

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dreikanter/notes-view/internal/renderer"
+	"github.com/dreikanter/notes-view/internal/index"
 )
 
 func TestLoadTemplates(t *testing.T) {
@@ -100,7 +100,7 @@ func TestRenderView(t *testing.T) {
 		},
 		NotePath:  "notes/test.md",
 		NoteTitle: "Test Note",
-		Frontmatter: &renderer.Frontmatter{
+		Note: &index.NoteEntry{
 			Title:       "Test Note",
 			Tags:        []string{"go", "testing"},
 			Description: "A test note",
@@ -182,7 +182,7 @@ func TestRenderNotePartial(t *testing.T) {
 	data := NotePartialData{
 		NotePath:  "2026/03/note.md",
 		NoteTitle: "March Note",
-		Frontmatter: &renderer.Frontmatter{
+		Note: &index.NoteEntry{
 			Title: "March Note",
 			Tags:  []string{"journal"},
 		},

--- a/web/templates/note_pane_body.html
+++ b/web/templates/note_pane_body.html
@@ -27,7 +27,7 @@
   </header>
   {{ end }}
   <div class="px-6 py-6 max-md:px-4 max-md:py-5 max-[480px]:px-3 max-[480px]:py-4">
-    {{ with .Frontmatter }}
+    {{ with .Note }}
     {{ if or .Title .Description .Tags }}
     <div class="pb-4 mb-6 border-b border-gray-200">
       {{ if .Title }}<h1 class="text-[28px] font-semibold leading-tight text-gray-900 mt-0 mb-2">{{ .Title }}</h1>{{ end }}


### PR DESCRIPTION
## Summary

- `renderer.Frontmatter` was a per-render copy of metadata that `NoteIndex` already parses at build time. Delete it, simplify `Render` to `(string, error)`, and pull metadata from the index in the handler.
- Add `Description` to `NoteEntry` and a new `NoteEntryByRel` lookup so the handler can read what the note-pane template needs.
- `goldmark-meta` stays registered so the YAML fence is still consumed; we just stop reading its output.
- Net: one parser instead of two, ~150 lines of duplicated code and tests gone.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (includes `TestViewStripsRedundantH1` integration)
- [x] Manual: open a note with `title`, `description`, and `tags` in frontmatter — banner renders as before
- [x] Manual: edit a note to change the title — SSE rebuild picks it up and the new title appears

## References

- closes #75
- relates to #67
- relates to #72