### PR TITLE
Await index rebuild before broadcasting SSE change

### DIFF
--- a/internal/index/note_index.go
+++ b/internal/index/note_index.go
@@ -47,15 +47,21 @@ type NoteEntry struct {
 // for concurrent use. Build performs a single filepath.WalkDir, parses
 // frontmatter once per file, and swaps all state in atomically.
 type NoteIndex struct {
-	root     string
-	logger   *slog.Logger
-	mu       sync.RWMutex
-	entries  []NoteEntry
-	byUID    map[string]string
-	byRel    map[string]int
-	byTag    map[string][]string
-	allTags  []string
-	building sync.Mutex
+	root    string
+	logger  *slog.Logger
+	mu      sync.RWMutex
+	entries []NoteEntry
+	byUID   map[string]string
+	byRel   map[string]int
+	byTag   map[string][]string
+	allTags []string
+
+	// buildMu guards curDone and queuedDone — the rebuild state machine.
+	// Separate from mu so Rebuild bookkeeping does not contend with read
+	// lookups. See Rebuild for the scheduling semantics.
+	buildMu    sync.Mutex
+	curDone    chan struct{} // in-flight build's completion signal; nil when idle
+	queuedDone chan struct{} // follow-up build queued while curDone runs; nil when none
 }
 
 // New creates a NoteIndex rooted at root. A nil logger is replaced with
@@ -169,18 +175,60 @@ func (i *NoteIndex) Build() error {
 	return nil
 }
 
-// Rebuild triggers a background index build, coalescing concurrent calls.
-// If a build is already in progress, the call returns immediately.
-func (i *NoteIndex) Rebuild() {
-	if !i.building.TryLock() {
-		return
+// Rebuild requests an index rebuild and returns a channel that closes
+// when a build has completed that reflects the tree state at or after
+// this call.
+//
+// Scheduling rules:
+//   - Idle: start a new build immediately.
+//   - Build in-flight: coalesce — queue at most one follow-up. Every
+//     caller that arrives while the in-flight build runs receives the
+//     same follow-up's done channel, so they only observe completion
+//     after a full walk that started after their request.
+//
+// Waiters that only need "the current build" can read the returned
+// channel; callers that do not care (e.g. warmup on a navigation) may
+// ignore it.
+func (i *NoteIndex) Rebuild() <-chan struct{} {
+	i.buildMu.Lock()
+	if i.curDone == nil {
+		done := make(chan struct{})
+		i.curDone = done
+		i.buildMu.Unlock()
+		go i.runBuild(done)
+		return done
 	}
-	go func() {
-		defer i.building.Unlock()
-		if err := i.Build(); err != nil {
-			i.logger.Error("note index rebuild failed", "err", err)
-		}
-	}()
+	if i.queuedDone == nil {
+		i.queuedDone = make(chan struct{})
+	}
+	done := i.queuedDone
+	i.buildMu.Unlock()
+	return done
+}
+
+// runBuild executes one Build and signals done; if another Rebuild
+// request arrived during the build, it chains into the follow-up build
+// in the same goroutine lineage.
+func (i *NoteIndex) runBuild(done chan struct{}) {
+	if err := i.Build(); err != nil {
+		i.logger.Error("note index rebuild failed", "err", err)
+	}
+
+	i.buildMu.Lock()
+	next := i.queuedDone
+	i.queuedDone = nil
+	if next != nil {
+		i.curDone = next
+	} else {
+		i.curDone = nil
+	}
+	i.buildMu.Unlock()
+
+	close(done)
+
+	if next != nil {
+		go i.runBuild(next)
+	}
 }
 
 // NoteByUID returns the forward-slash rel-path for a UID and a boolean

--- a/internal/index/note_index_test.go
+++ b/internal/index/note_index_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -677,3 +678,82 @@ func TestIsUID(t *testing.T) {
 		})
 	}
 }
+
+// TestRebuildDoneReflectsLatestState pins that reading the channel
+// returned from Rebuild guarantees a Build has completed against the
+// tree state at or after the Rebuild call. Without this guarantee the
+// SSE broadcast at sse.go could fire before the index catches up,
+// causing handleView to read stale metadata.
+func TestRebuildDoneReflectsLatestState(t *testing.T) {
+	dir := t.TempDir()
+	idx := New(dir, nil)
+	if err := idx.Build(); err != nil {
+		t.Fatalf("initial Build: %v", err)
+	}
+
+	mustWriteFile(t, filepath.Join(dir, "fresh.md"),
+		"---\ntitle: Fresh\n---\n")
+
+	if _, ok := idx.NoteEntryByRel("fresh.md"); ok {
+		t.Fatal("fresh.md should not be indexed before Rebuild")
+	}
+
+	<-idx.Rebuild()
+
+	entry, ok := idx.NoteEntryByRel("fresh.md")
+	if !ok {
+		t.Fatal("fresh.md should be indexed after Rebuild done fires")
+	}
+	if entry.Title != "Fresh" {
+		t.Errorf("Title = %q, want Fresh", entry.Title)
+	}
+}
+
+// TestRebuildCoalescesRequestsDuringInflight pins the scheduling rule:
+// while a build is in-flight, all new Rebuild callers share a single
+// queued follow-up. Verified by observing that the request arriving
+// after a write is reflected by the time the returned channel closes.
+func TestRebuildCoalescesRequestsDuringInflight(t *testing.T) {
+	dir := t.TempDir()
+	// Prime the tree with enough files that Build takes measurable time.
+	for i := 0; i < 200; i++ {
+		mustWriteFile(t, filepath.Join(dir, "n"+strconv.Itoa(i)+".md"),
+			"---\ntitle: T\n---\n")
+	}
+
+	idx := New(dir, nil)
+	if err := idx.Build(); err != nil {
+		t.Fatalf("initial Build: %v", err)
+	}
+
+	// Kick off a build, then — without waiting — add a new file and
+	// request another rebuild. The second call must return a channel
+	// that reflects the new file, not the prior in-flight build.
+	first := idx.Rebuild()
+
+	mustWriteFile(t, filepath.Join(dir, "late.md"),
+		"---\ntitle: Late\n---\n")
+
+	second := idx.Rebuild()
+
+	// Second must not close before first (queue ordering).
+	select {
+	case <-second:
+		// If this ever fires before first, the queued build was elided.
+		select {
+		case <-first:
+			// Both closed at roughly the same time — acceptable if
+			// first finished between the two reads.
+		default:
+			t.Fatal("second done closed before in-flight build finished")
+		}
+	case <-first:
+	}
+
+	<-second
+
+	if _, ok := idx.NoteEntryByRel("late.md"); !ok {
+		t.Error("late.md must be indexed once second Rebuild's done fires")
+	}
+}
+

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -87,15 +87,18 @@ func (h *SSEHub) eventLoop() {
 				continue
 			}
 			// Content (frontmatter) and filenames (UIDs) can both
-			// change on Write or Create — rebuild once either way.
-			if h.index != nil {
-				h.index.Rebuild()
-			}
+			// change on Write or Create. The rebuild is scheduled
+			// inside the debounce timer below so the broadcast only
+			// fires after a build that reflects this event — clients
+			// that re-fetch on `change` always see fresh metadata.
 			p := event.Name
 			if t, ok := timers[p]; ok {
 				t.Stop()
 			}
 			timers[p] = time.AfterFunc(100*time.Millisecond, func() {
+				if h.index != nil {
+					<-h.index.Rebuild()
+				}
 				h.broadcast(p)
 			})
 		case err, ok := <-h.watcher.Errors:


### PR DESCRIPTION
## Summary

- `Rebuild` previously returned immediately and ran `Build` in a goroutine, so the 100ms SSE debounce could fire while the index was still mid-walk. Clients re-fetching on `change` then rendered fresh bytes with stale metadata.
- `Rebuild` now returns `<-chan struct{}` that closes only when a build started at or after the call completes. Coalescing preserved: while a build is in-flight, all new callers share a single queued follow-up.
- SSE hub moves the rebuild into the debounce timer and awaits it before broadcasting; every `change` the client sees reflects a consistent index.

## Test plan

- [x] `go test -race ./...`
- [x] `TestRebuildDoneReflectsLatestState` — channel does not close until a post-call Build is visible via `NoteEntryByRel`.
- [x] `TestRebuildCoalescesRequestsDuringInflight` — request arriving during an in-flight build observes its own state by the time its channel closes.
- [x] Manual: edit a note's title in a loop, observe that the metadata banner always matches the body on reload.

## References

- closes #77
- relates to #76