### PR TITLE
NoteIndex follow-ups: collapse entries, harden runBuild, tidy

### DIFF
--- a/internal/index/note_index.go
+++ b/internal/index/note_index.go
@@ -31,16 +31,21 @@ func IsUID(s string) bool {
 // needed for today's lookups are populated for future derived maps
 // (bySlug, byAlias, byDate) without requiring a second walk.
 type NoteEntry struct {
-	RelPath     string
-	UID         string
-	Stem        string
+	// Identity.
+	RelPath string
+	UID     string
+	Stem    string
+
+	// Frontmatter-derived.
 	Slug        string
 	Title       string
 	Description string
 	Tags        []string
 	Aliases     []string
-	Date        time.Time
-	DateSource  string
+
+	// Temporal.
+	Date       time.Time
+	DateSource string
 }
 
 // NoteIndex is the unified in-memory index of the notes tree. It is safe
@@ -50,9 +55,8 @@ type NoteIndex struct {
 	root    string
 	logger  *slog.Logger
 	mu      sync.RWMutex
-	entries []NoteEntry
 	byUID   map[string]string
-	byRel   map[string]int
+	byRel   map[string]NoteEntry
 	byTag   map[string][]string
 	allTags []string
 
@@ -74,7 +78,7 @@ func New(root string, logger *slog.Logger) *NoteIndex {
 		root:   root,
 		logger: logger,
 		byUID:  make(map[string]string),
-		byRel:  make(map[string]int),
+		byRel:  make(map[string]NoteEntry),
 		byTag:  make(map[string][]string),
 	}
 }
@@ -83,9 +87,8 @@ func New(root string, logger *slog.Logger) *NoteIndex {
 // state. The swap at the end is atomic. Non-permission walk errors are
 // propagated; permission-denied directories are warned and skipped.
 func (i *NoteIndex) Build() error {
-	var entries []NoteEntry
 	byUID := make(map[string]string)
-	byRel := make(map[string]int)
+	byRel := make(map[string]NoteEntry)
 	byTag := make(map[string][]string)
 
 	err := filepath.WalkDir(i.root, func(path string, d os.DirEntry, err error) error {
@@ -129,7 +132,7 @@ func (i *NoteIndex) Build() error {
 		}
 		date, source := resolveDate(uid, fm.Date, info)
 
-		entry := NoteEntry{
+		byRel[rel] = NoteEntry{
 			RelPath:     rel,
 			UID:         uid,
 			Stem:        stem,
@@ -137,12 +140,10 @@ func (i *NoteIndex) Build() error {
 			Title:       fm.Title,
 			Description: fm.Description,
 			Tags:        tags,
-			Aliases:     append([]string(nil), fm.Aliases...),
+			Aliases:     fm.Aliases,
 			Date:        date,
 			DateSource:  source,
 		}
-		byRel[rel] = len(entries)
-		entries = append(entries, entry)
 
 		if uid != "" {
 			byUID[uid] = rel
@@ -166,7 +167,6 @@ func (i *NoteIndex) Build() error {
 	}
 
 	i.mu.Lock()
-	i.entries = entries
 	i.byUID = byUID
 	i.byRel = byRel
 	i.byTag = byTag
@@ -209,25 +209,32 @@ func (i *NoteIndex) Rebuild() <-chan struct{} {
 // runBuild executes one Build and signals done; if another Rebuild
 // request arrived during the build, it chains into the follow-up build
 // in the same goroutine lineage.
+//
+// The state-machine cleanup runs in a deferred block so that even if
+// Build panics, waiters on done are released and any queued follow-up
+// still gets scheduled — without this, an SSE timer goroutine would
+// block forever.
 func (i *NoteIndex) runBuild(done chan struct{}) {
+	defer func() {
+		i.buildMu.Lock()
+		next := i.queuedDone
+		i.queuedDone = nil
+		if next != nil {
+			i.curDone = next
+		} else {
+			i.curDone = nil
+		}
+		i.buildMu.Unlock()
+
+		close(done)
+
+		if next != nil {
+			go i.runBuild(next)
+		}
+	}()
+
 	if err := i.Build(); err != nil {
 		i.logger.Error("note index rebuild failed", "err", err)
-	}
-
-	i.buildMu.Lock()
-	next := i.queuedDone
-	i.queuedDone = nil
-	if next != nil {
-		i.curDone = next
-	} else {
-		i.curDone = nil
-	}
-	i.buildMu.Unlock()
-
-	close(done)
-
-	if next != nil {
-		go i.runBuild(next)
 	}
 }
 
@@ -247,13 +254,12 @@ func (i *NoteIndex) NoteByUID(uid string) (string, bool) {
 func (i *NoteIndex) NoteEntryByRel(rel string) (NoteEntry, bool) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	idx, ok := i.byRel[rel]
+	entry, ok := i.byRel[rel]
 	if !ok {
 		return NoteEntry{}, false
 	}
-	entry := i.entries[idx]
-	entry.Tags = append([]string(nil), entry.Tags...)
-	entry.Aliases = append([]string(nil), entry.Aliases...)
+	entry.Tags = cloneStrings(entry.Tags)
+	entry.Aliases = cloneStrings(entry.Aliases)
 	return entry, true
 }
 
@@ -261,9 +267,7 @@ func (i *NoteIndex) NoteEntryByRel(rel string) (NoteEntry, bool) {
 func (i *NoteIndex) Tags() []string {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	out := make([]string, len(i.allTags))
-	copy(out, i.allTags)
-	return out
+	return cloneStrings(i.allTags)
 }
 
 // NotesByTag returns a copy of the sorted rel-path slice for a tag.
@@ -271,10 +275,7 @@ func (i *NoteIndex) Tags() []string {
 func (i *NoteIndex) NotesByTag(tag string) []string {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	paths := i.byTag[tag]
-	out := make([]string, len(paths))
-	copy(out, paths)
-	return out
+	return cloneStrings(i.byTag[tag])
 }
 
 // deriveSlug returns the normalized slug for an entry. If the frontmatter
@@ -370,6 +371,15 @@ func uidDate(uid string) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	return t, true
+}
+
+// cloneStrings returns a fresh copy of s. A nil input yields a non-nil,
+// zero-length slice so callers always get a usable value — matching the
+// "unknown returns empty slice" contract in NotesByTag.
+func cloneStrings(s []string) []string {
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
 }
 
 // dedupStrings returns s with duplicates removed, preserving first-seen

--- a/internal/index/note_index.go
+++ b/internal/index/note_index.go
@@ -219,11 +219,7 @@ func (i *NoteIndex) runBuild(done chan struct{}) {
 		i.buildMu.Lock()
 		next := i.queuedDone
 		i.queuedDone = nil
-		if next != nil {
-			i.curDone = next
-		} else {
-			i.curDone = nil
-		}
+		i.curDone = next
 		i.buildMu.Unlock()
 
 		close(done)

--- a/internal/index/note_index_test.go
+++ b/internal/index/note_index_test.go
@@ -354,21 +354,6 @@ func TestNotesByTagSortedRelPaths(t *testing.T) {
 	}
 }
 
-// entryByRel is a test helper that returns the entry at rel, or fails the
-// test. Reads unexported state — tests run in package index.
-func entryByRel(t *testing.T, idx *NoteIndex, rel string) NoteEntry {
-	t.Helper()
-	idx.mu.RLock()
-	defer idx.mu.RUnlock()
-	for _, e := range idx.entries {
-		if e.RelPath == rel {
-			return e
-		}
-	}
-	t.Fatalf("no entry with RelPath %q; have %d entries", rel, len(idx.entries))
-	return NoteEntry{}
-}
-
 func TestNoteEntryTitle(t *testing.T) {
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "a.md"), "---\ntitle: Hello World\n---\n")
@@ -378,11 +363,13 @@ func TestNoteEntryTitle(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if got := entryByRel(t, idx, "a.md").Title; got != "Hello World" {
-		t.Errorf("Title = %q, want Hello World", got)
+	a, _ := idx.NoteEntryByRel("a.md")
+	if a.Title != "Hello World" {
+		t.Errorf("Title = %q, want Hello World", a.Title)
 	}
-	if got := entryByRel(t, idx, "b.md").Title; got != "" {
-		t.Errorf("Title = %q, want empty", got)
+	b, _ := idx.NoteEntryByRel("b.md")
+	if b.Title != "" {
+		t.Errorf("Title = %q, want empty", b.Title)
 	}
 }
 
@@ -396,11 +383,13 @@ func TestNoteEntryDescription(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if got := entryByRel(t, idx, "a.md").Description; got != "A short summary" {
-		t.Errorf("Description = %q, want %q", got, "A short summary")
+	a, _ := idx.NoteEntryByRel("a.md")
+	if a.Description != "A short summary" {
+		t.Errorf("Description = %q, want %q", a.Description, "A short summary")
 	}
-	if got := entryByRel(t, idx, "b.md").Description; got != "" {
-		t.Errorf("Description = %q, want empty", got)
+	b, _ := idx.NoteEntryByRel("b.md")
+	if b.Description != "" {
+		t.Errorf("Description = %q, want empty", b.Description)
 	}
 }
 
@@ -472,13 +461,13 @@ func TestNoteEntryAliases(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	got := entryByRel(t, idx, "inline.md").Aliases
-	if len(got) != 2 || got[0] != "k8s" || got[1] != "kube" {
-		t.Errorf("inline Aliases = %v", got)
+	inline, _ := idx.NoteEntryByRel("inline.md")
+	if len(inline.Aliases) != 2 || inline.Aliases[0] != "k8s" || inline.Aliases[1] != "kube" {
+		t.Errorf("inline Aliases = %v", inline.Aliases)
 	}
-	got = entryByRel(t, idx, "block.md").Aliases
-	if len(got) != 2 || got[0] != "one" || got[1] != "two" {
-		t.Errorf("block Aliases = %v", got)
+	block, _ := idx.NoteEntryByRel("block.md")
+	if len(block.Aliases) != 2 || block.Aliases[0] != "one" || block.Aliases[1] != "two" {
+		t.Errorf("block Aliases = %v", block.Aliases)
 	}
 }
 
@@ -491,8 +480,9 @@ func TestNoteEntrySlugFromFrontmatter(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if got := entryByRel(t, idx, "a.md").Slug; got != "my-awesome-note" {
-		t.Errorf("Slug = %q, want my-awesome-note", got)
+	a, _ := idx.NoteEntryByRel("a.md")
+	if a.Slug != "my-awesome-note" {
+		t.Errorf("Slug = %q, want my-awesome-note", a.Slug)
 	}
 }
 
@@ -506,16 +496,19 @@ func TestNoteEntrySlugDerivedFromStem(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if got := entryByRel(t, idx, "20260331_9201_weekly_digest.md").Slug; got != "weekly-digest" {
-		t.Errorf("Slug = %q, want weekly-digest", got)
+	weekly, _ := idx.NoteEntryByRel("20260331_9201_weekly_digest.md")
+	if weekly.Slug != "weekly-digest" {
+		t.Errorf("Slug = %q, want weekly-digest", weekly.Slug)
 	}
 	// Bare UID filename → empty slug.
-	if got := entryByRel(t, idx, "20260331_9202.md").Slug; got != "" {
-		t.Errorf("Slug = %q, want empty", got)
+	bare, _ := idx.NoteEntryByRel("20260331_9202.md")
+	if bare.Slug != "" {
+		t.Errorf("Slug = %q, want empty", bare.Slug)
 	}
 	// Non-UID filename → normalized stem.
-	if got := entryByRel(t, idx, "README.md").Slug; got != "readme" {
-		t.Errorf("Slug = %q, want readme", got)
+	readme, _ := idx.NoteEntryByRel("README.md")
+	if readme.Slug != "readme" {
+		t.Errorf("Slug = %q, want readme", readme.Slug)
 	}
 }
 
@@ -527,7 +520,7 @@ func TestNoteEntryDateFromUID(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	e := entryByRel(t, idx, "20260331_9201.md")
+	e, _ := idx.NoteEntryByRel("20260331_9201.md")
 	if e.DateSource != "uid" {
 		t.Errorf("DateSource = %q, want uid", e.DateSource)
 	}
@@ -544,7 +537,7 @@ func TestNoteEntryDateFromFrontmatterWhenNoUID(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	e := entryByRel(t, idx, "README.md")
+	e, _ := idx.NoteEntryByRel("README.md")
 	if e.DateSource != "frontmatter" {
 		t.Errorf("DateSource = %q, want frontmatter", e.DateSource)
 	}
@@ -568,7 +561,7 @@ func TestNoteEntryDateFromMtimeWhenNoUIDAndNoFrontmatterDate(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	e := entryByRel(t, idx, "plain.md")
+	e, _ := idx.NoteEntryByRel("plain.md")
 	if e.DateSource != "mtime" {
 		t.Errorf("DateSource = %q, want mtime", e.DateSource)
 	}
@@ -587,7 +580,7 @@ func TestNoteEntryDateUIDInvalidFallsThrough(t *testing.T) {
 	if err := idx.Build(); err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	e := entryByRel(t, idx, "20269931_0001.md")
+	e, _ := idx.NoteEntryByRel("20269931_0001.md")
 	if e.DateSource != "frontmatter" {
 		t.Errorf("DateSource = %q, want frontmatter (UID date invalid)", e.DateSource)
 	}
@@ -611,7 +604,7 @@ func TestMalformedFrontmatterDoesNotFailBuild(t *testing.T) {
 		t.Error("sibling UID entry should still be indexed")
 	}
 	// The malformed file is still recorded as an entry (no UID, no tags).
-	e := entryByRel(t, idx, "bad.md")
+	e, _ := idx.NoteEntryByRel("bad.md")
 	if len(e.Tags) != 0 {
 		t.Errorf("bad.md tags = %v, want none", e.Tags)
 	}


### PR DESCRIPTION
## Summary

- Collapse `entries []NoteEntry` + `byRel map[string]int` into a single `byRel map[string]NoteEntry`; drop the redundant `Aliases` copy in `Build`.
- Harden `runBuild` with a `defer` so a panic in `Build` still releases waiters and schedules the queued follow-up — otherwise the SSE timer goroutine in #78 would hang forever.
- Add `cloneStrings` helper and use it in `Tags`, `NotesByTag`, `NoteEntryByRel` (three different copy idioms became one).
- Group `NoteEntry` fields semantically: identity, frontmatter-derived, temporal.
- Retire the `entryByRel` test helper — callers now go through the public `NoteEntryByRel`; tests no longer read unexported state.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`

## References

- closes #79
- relates to #76
- relates to #78