### PR TITLE
Use Lucide SVG icons for tree view folder, file, and toggle

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -19,7 +19,7 @@ func TestIntegrationSmoke(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "2026", "03"), 0o755)
 	os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Welcome\n\nHello world.\n"), 0o644)
 	os.WriteFile(filepath.Join(dir, "2026", "03", "20260331_9201_todo.md"),
-		[]byte("---\ntitle: Daily Todo\ntags: [todo]\n---\n# Daily Todo\n\n- [+] Done task\n- [ ] Pending task\n- [daily] Routine\n\nSee [readme](../../README.md) and note://20260331_9201.\n"), 0o644)
+		[]byte("---\ntitle: Daily Todo\ntags: [todo]\n---\n# Daily Todo\n\n- [x] Done task\n- [ ] Pending task\n- [daily] Routine\n\nSee [readme](../../README.md) and note://20260331_9201.\n"), 0o644)
 
 	srv, err := server.NewServer(dir, "", nil)
 	if err != nil {

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -38,6 +38,7 @@ func NewRenderer(idx *index.NoteIndex) *Renderer {
 			extension.GFM,
 			meta.Meta,
 			NoteLinkExtension,
+			TaskCheckBoxExtension,
 		),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),

--- a/internal/renderer/tasks.go
+++ b/internal/renderer/tasks.go
@@ -5,18 +5,20 @@ import (
 	"strings"
 )
 
+const (
+	svgTaskUnchecked = `<svg class="task-unchecked" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/></svg>`
+	svgTaskChecked   = `<svg class="task-checked" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="m9 12 2 2 4-4"/></svg>`
+)
+
 // GFM converts [ ] and [x] to checkbox inputs; we replace those rendered forms.
 // [+] is not a GFM task marker so it passes through as literal text.
 var taskPatterns = []struct {
 	marker  string
 	replace string
 }{
-	// GFM unchecked checkbox → task-unchecked span
-	{`<input disabled="" type="checkbox"> `, `<span class="task-unchecked"></span> `},
-	// GFM checked checkbox → task-checked span (fallback, in case [x] is used)
-	{`<input checked="" disabled="" type="checkbox"> `, `<span class="task-checked">&#10003;</span> `},
-	// [+] passes through goldmark as literal text
-	{"[+] ", `<span class="task-checked">&#10003;</span> `},
+	{`<input disabled="" type="checkbox"> `, svgTaskUnchecked + ` `},
+	{`<input checked="" disabled="" type="checkbox"> `, svgTaskChecked + ` `},
+	{"[+] ", svgTaskChecked + ` `},
 }
 
 var dailyPattern = regexp.MustCompile(`\[daily\]\s*`)

--- a/internal/renderer/tasks.go
+++ b/internal/renderer/tasks.go
@@ -2,7 +2,12 @@ package renderer
 
 import (
 	"regexp"
-	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	east "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
 )
 
 const (
@@ -10,23 +15,40 @@ const (
 	svgTaskChecked   = `<svg class="task-checked" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="m9 12 2 2 4-4"/></svg>`
 )
 
-// GFM converts [ ] and [x] to checkbox inputs; we replace those rendered forms.
-// [+] is not a GFM task marker so it passes through as literal text.
-var taskPatterns = []struct {
-	marker  string
-	replace string
-}{
-	{`<input disabled="" type="checkbox"> `, svgTaskUnchecked + ` `},
-	{`<input checked="" disabled="" type="checkbox"> `, svgTaskChecked + ` `},
-	{"[+] ", svgTaskChecked + ` `},
+// TaskCheckBoxExtension replaces goldmark's default <input type="checkbox">
+// output for GFM task items with inline Lucide SVG icons.
+var TaskCheckBoxExtension goldmark.Extender = &taskCheckBoxExtension{}
+
+type taskCheckBoxExtension struct{}
+
+func (e *taskCheckBoxExtension) Extend(m goldmark.Markdown) {
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(&taskCheckBoxRenderer{}, 100),
+		),
+	)
+}
+
+type taskCheckBoxRenderer struct{}
+
+func (r *taskCheckBoxRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(east.KindTaskCheckBox, r.renderTaskCheckBox)
+}
+
+func (r *taskCheckBoxRenderer) renderTaskCheckBox(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	if node.(*east.TaskCheckBox).IsChecked {
+		_, _ = w.WriteString(svgTaskChecked)
+	} else {
+		_, _ = w.WriteString(svgTaskUnchecked)
+	}
+	return ast.WalkContinue, nil
 }
 
 var dailyPattern = regexp.MustCompile(`\[daily\]\s*`)
 
 func processTaskSyntax(html string) string {
-	for _, p := range taskPatterns {
-		html = strings.ReplaceAll(html, p.marker, p.replace)
-	}
-	html = dailyPattern.ReplaceAllString(html, `<span class="task-tag">daily</span> `)
-	return html
+	return dailyPattern.ReplaceAllString(html, `<span class="task-tag">daily</span> `)
 }

--- a/internal/renderer/tasks.go
+++ b/internal/renderer/tasks.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	svgTaskUnchecked = `<svg class="task-unchecked" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/></svg>`
-	svgTaskChecked   = `<svg class="task-checked" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="m9 12 2 2 4-4"/></svg>`
+	svgTaskUnchecked = `<svg class="task-unchecked" role="img" aria-label="task incomplete" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/></svg>`
+	svgTaskChecked   = `<svg class="task-checked" role="img" aria-label="task complete" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="m9 12 2 2 4-4"/></svg>`
 )
 
 // TaskCheckBoxExtension replaces goldmark's default <input type="checkbox">

--- a/internal/renderer/tasks_test.go
+++ b/internal/renderer/tasks_test.go
@@ -13,7 +13,7 @@ func TestTaskSyntax(t *testing.T) {
 	}{
 		{
 			"completed task",
-			"- [+] Done item",
+			"- [x] Done item",
 			[]string{`class="task-checked"`, "Done item"},
 		},
 		{

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -13,7 +13,7 @@ func setupTestServer(t *testing.T) (*Server, string) {
 	t.Helper()
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, "2026", "03"), 0o755)
-	os.WriteFile(filepath.Join(dir, "2026", "03", "20260331_9201_todo.md"), []byte("---\ntitle: Todo\ntags: [todo, daily]\n---\n# Todo\n- [+] Done\n- [ ] Pending\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "2026", "03", "20260331_9201_todo.md"), []byte("---\ntitle: Todo\ntags: [todo, daily]\n---\n# Todo\n- [x] Done\n- [ ] Pending\n"), 0o644)
 	os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Welcome\nHello"), 0o644)
 	srv, err := NewServer(dir, "", nil)
 	if err != nil {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -137,15 +137,13 @@ html.sidebar-open #note-pane {
   }
 
   .task-checked {
-    @apply inline-flex items-center justify-center w-4 h-4 bg-green-700
-           dark:bg-green-600 text-white rounded-sm text-[11px] font-bold
-           align-middle mr-0.5 flex-shrink-0;
+    @apply inline-block w-4 h-4 align-middle mr-0.5 flex-shrink-0
+           text-green-700 dark:text-green-600;
   }
 
   .task-unchecked {
-    @apply inline-block w-4 h-4 border-2 border-gray-300 dark:border-gray-600
-           rounded-sm align-middle mr-0.5 bg-white dark:bg-gray-800
-           flex-shrink-0;
+    @apply inline-block w-4 h-4 align-middle mr-0.5 flex-shrink-0
+           text-gray-400 dark:text-gray-500;
   }
 
   .task-tag {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -137,13 +137,15 @@ html.sidebar-open #note-pane {
   }
 
   .task-checked {
-    @apply inline-block w-4 h-4 align-middle mr-0.5 flex-shrink-0
+    @apply inline-block w-[1em] h-[1em] mr-[0.25em]
            text-green-700 dark:text-green-600;
+    vertical-align: -0.125em;
   }
 
   .task-unchecked {
-    @apply inline-block w-4 h-4 align-middle mr-0.5 flex-shrink-0
+    @apply inline-block w-[1em] h-[1em] mr-[0.25em]
            text-gray-400 dark:text-gray-500;
+    vertical-align: -0.125em;
   }
 
   .task-tag {

--- a/web/src/tree-view.js
+++ b/web/src/tree-view.js
@@ -145,6 +145,11 @@ export class TreeView {
       btn.setAttribute('data-expanded', 'false')
       btn.innerHTML = SQUARE_PLUS_SVG
       row.appendChild(btn)
+    } else {
+      const spacer = document.createElement('span')
+      spacer.className = `${this._cls('toggle-spacer')} w-4 flex-shrink-0`
+      spacer.setAttribute('aria-hidden', 'true')
+      row.appendChild(spacer)
     }
 
     const href = typeof this.rowHref === 'function' ? this.rowHref(node) : null

--- a/web/src/tree-view.js
+++ b/web/src/tree-view.js
@@ -135,14 +135,14 @@ export class TreeView {
     if (node.isDir) {
       const btn = document.createElement('button')
       btn.type = 'button'
-      btn.className = `${this._cls('toggle')} flex items-center justify-center w-8 flex-shrink-0 text-gray-400 dark:text-gray-500 cursor-pointer bg-transparent border-0 p-0`
+      btn.className = `${this._cls('toggle')} flex items-center justify-center w-4 flex-shrink-0 text-gray-400 dark:text-gray-500 cursor-pointer bg-transparent border-0 p-0`
       btn.setAttribute('tabindex', '-1')
       btn.setAttribute('aria-hidden', 'true')
       btn.textContent = '\u25B8'
       row.appendChild(btn)
     } else {
       const spacer = document.createElement('span')
-      spacer.className = `${this._cls('toggle-spacer')} w-8 flex-shrink-0`
+      spacer.className = `${this._cls('toggle-spacer')} w-4 flex-shrink-0`
       row.appendChild(spacer)
     }
 
@@ -155,13 +155,15 @@ export class TreeView {
     }
 
     const icon = document.createElement('span')
-    icon.className = `${this._cls('icon')} flex-shrink-0`
+    icon.className = `${this._cls('icon')} flex-shrink-0 inline-flex items-center`
     if (typeof this.renderIcon === 'function') {
       const result = this.renderIcon(node)
       if (typeof result === 'string') icon.textContent = result
       else if (result instanceof Node) icon.appendChild(result)
     } else {
-      icon.textContent = node.isDir ? '\uD83D\uDCC1' : '\uD83D\uDCC4'
+      icon.innerHTML = node.isDir
+        ? '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>'
+        : '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>'
     }
     link.appendChild(icon)
 

--- a/web/src/tree-view.js
+++ b/web/src/tree-view.js
@@ -163,6 +163,7 @@ export class TreeView {
 
     const icon = document.createElement('span')
     icon.className = `${this._cls('icon')} flex-shrink-0 inline-flex items-center`
+    icon.setAttribute('aria-hidden', 'true')
     if (typeof this.renderIcon === 'function') {
       const result = this.renderIcon(node)
       if (typeof result === 'string') icon.textContent = result

--- a/web/src/tree-view.js
+++ b/web/src/tree-view.js
@@ -130,7 +130,8 @@ export class TreeView {
     li.setAttribute('aria-level', String(level))
     li.setAttribute('aria-selected', 'false')
     li.setAttribute('tabindex', '-1')
-    li.style.setProperty('--tv-depth', String(level - 1))
+    const depth = node.isDir ? level - 1 : Math.max(0, level - 2)
+    li.style.setProperty('--tv-depth', String(depth))
     if (node.isDir) li.setAttribute('aria-expanded', 'false')
 
     const row = document.createElement('div')

--- a/web/src/tree-view.js
+++ b/web/src/tree-view.js
@@ -140,10 +140,6 @@ export class TreeView {
       btn.setAttribute('aria-hidden', 'true')
       btn.textContent = '\u25B8'
       row.appendChild(btn)
-    } else {
-      const spacer = document.createElement('span')
-      spacer.className = `${this._cls('toggle-spacer')} w-4 flex-shrink-0`
-      row.appendChild(spacer)
     }
 
     const href = typeof this.rowHref === 'function' ? this.rowHref(node) : null

--- a/web/src/tree-view.js
+++ b/web/src/tree-view.js
@@ -29,6 +29,9 @@ function escapeSelector(s) {
   return String(s).replace(/["\\[\]]/g, '\\$&')
 }
 
+const SQUARE_PLUS_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M8 12h8"/><path d="M12 8v8"/></svg>'
+const SQUARE_MINUS_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M8 12h8"/></svg>'
+
 export class TreeView {
   constructor(container, options) {
     if (!container) throw new Error('TreeView: container is required')
@@ -138,7 +141,8 @@ export class TreeView {
       btn.className = `${this._cls('toggle')} flex items-center justify-center w-4 flex-shrink-0 text-gray-400 dark:text-gray-500 cursor-pointer bg-transparent border-0 p-0`
       btn.setAttribute('tabindex', '-1')
       btn.setAttribute('aria-hidden', 'true')
-      btn.textContent = '\u25B8'
+      btn.setAttribute('data-expanded', 'false')
+      btn.innerHTML = SQUARE_PLUS_SVG
       row.appendChild(btn)
     }
 
@@ -350,7 +354,8 @@ export class TreeView {
     const toggleCls = this._cls('toggle')
     for (const child of row.children) {
       if (child.classList && child.classList.contains(toggleCls)) {
-        child.textContent = expanded ? '\u25BE' : '\u25B8'
+        child.setAttribute('data-expanded', expanded ? 'true' : 'false')
+        child.innerHTML = expanded ? SQUARE_MINUS_SVG : SQUARE_PLUS_SVG
         return
       }
     }

--- a/web/src/tree-view.js
+++ b/web/src/tree-view.js
@@ -135,7 +135,8 @@ export class TreeView {
     if (node.isDir) li.setAttribute('aria-expanded', 'false')
 
     const row = document.createElement('div')
-    row.className = `${this._cls('row')} flex items-center gap-2 px-4 py-2 text-sm`
+    row.className = `${this._cls('row')} flex items-center gap-2 pr-4 py-2 text-sm`
+    row.style.paddingLeft = `calc(1rem + var(--tv-depth) * 1rem)`
     if (node.isDir) {
       const btn = document.createElement('button')
       btn.type = 'button'
@@ -187,7 +188,6 @@ export class TreeView {
     row.appendChild(link)
 
     li.appendChild(row)
-    li.style.paddingLeft = `calc(var(--tv-depth) * 1rem)`
     return li
   }
 

--- a/web/src/tree-view.test.js
+++ b/web/src/tree-view.test.js
@@ -184,15 +184,15 @@ describe('TreeView expand/collapse', () => {
     expect(tv.loadingPaths.size).toBe(0)
   })
 
-  it('chevron text flips between ▸ and ▾ on expand/collapse', async () => {
+  it('toggle state flips between collapsed and expanded on expand/collapse', async () => {
     const tv = new TreeView(container, { loader: makeLoader(nested) })
     await tv.ready
     const toggle = container.querySelector('[data-path="a"] .tv-toggle')
-    expect(toggle.textContent).toBe('\u25B8')
+    expect(toggle.getAttribute('data-expanded')).toBe('false')
     await tv.expand('a')
-    expect(toggle.textContent).toBe('\u25BE')
+    expect(toggle.getAttribute('data-expanded')).toBe('true')
     tv.collapse('a')
-    expect(toggle.textContent).toBe('\u25B8')
+    expect(toggle.getAttribute('data-expanded')).toBe('false')
   })
 })
 

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ if .Title }}{{ .Title }} — {{ end }}notesview</title>
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23333' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z'/%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+PGcgc3Ryb2tlPSIjMzM0MTU1IiBzdHJva2Utd2lkdGg9IjEwIiBzdHJva2UtbGluZWNhcD0icm91bmQiPjxsaW5lIHgxPSIxNSIgeTE9IjIwIiB4Mj0iODUiIHkyPSIyMCIvPjxsaW5lIHgxPSIxNSIgeTE9IjQwIiB4Mj0iODUiIHkyPSI0MCIvPjxsaW5lIHgxPSIxNSIgeTE9IjYwIiB4Mj0iODUiIHkyPSI2MCIvPjxsaW5lIHgxPSIxNSIgeTE9IjgwIiB4Mj0iODUiIHkyPSI4MCIvPjwvZz48L3N2Zz4=">
   <script>
     // Pre-paint: decide theme and sidebar state from localStorage before
     // first render so the user never sees a flash of the wrong theme.


### PR DESCRIPTION
## Summary

- Shrink chevron column from `w-8` to `w-4`.
- Replace folder/file emoji with inline Lucide SVGs.
- Replace chevron `▸`/`▾` with Lucide `square-plus`/`square-minus`; state exposed via `data-expanded` on the toggle button.
- Move the per-level indent from `<li>` padding onto the row. Ancestor `<li>` paddings were compounding through the nested `<ul>` chain, so each extra depth added more than 1rem; the row-padding approach keeps the step linear.
- Align leaf rows with their parent dir instead of indenting one level further, so siblings share a single indent column.
- Leaf rows carry a chevron-width spacer so file and folder icons land on the same vertical line.
- Replace pseudo-checkbox task markers with Lucide `square` / `square-check` SVGs, rendered via a custom goldmark `NodeRenderer` for `east.KindTaskCheckBox` instead of regex post-processing on the HTML.
- Drop the non-standard `[+]` task marker — `[x]` is now the only checked form.
- Replace the Lucide star favicon with the four-lines favicon used by `notes-pub` for cross-project consistency.

## References

- relates to #95

https://claude.ai/code/session_01CmFKjoXjK3WSBQcCW1tccc