### PR TITLE
Refactor: rename SidebarPartialData to SidebarData and consolidate logic

### DIFF
--- a/internal/renderer/noteext.go
+++ b/internal/renderer/noteext.go
@@ -45,11 +45,10 @@ func (p *wikiLinkParser) Parse(parent ast.Node, block text.Reader, pc parser.Con
 	}
 	inner := line[2 : 2+end]
 
-	// Validate UID pattern: 8 digits + '_' + 4+ digits
-	if !isValidUID(inner) {
+	uid := string(inner)
+	if !index.IsUID(uid) {
 		return nil
 	}
-	uid := string(inner)
 
 	stateAny := pc.Get(noteLinkStateKey)
 	if stateAny == nil {
@@ -72,28 +71,6 @@ func (p *wikiLinkParser) Parse(parent ast.Node, block text.Reader, pc parser.Con
 	link.SetAttributeString("class", []byte("uid-link"))
 	link.AppendChild(link, ast.NewString([]byte(uid)))
 	return link
-}
-
-// isValidUID checks if b matches the UID pattern: exactly 8 digits,
-// an underscore, then 4 or more digits.
-func isValidUID(b []byte) bool {
-	if len(b) < 13 { // 8 + 1 + 4 minimum
-		return false
-	}
-	for i := 0; i < 8; i++ {
-		if b[i] < '0' || b[i] > '9' {
-			return false
-		}
-	}
-	if b[8] != '_' {
-		return false
-	}
-	for i := 9; i < len(b); i++ {
-		if b[i] < '0' || b[i] > '9' {
-			return false
-		}
-	}
-	return true
 }
 
 // noteLinkStateKey identifies per-request state stored in parser.Context.

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -71,22 +71,15 @@ func (r *Renderer) Render(source []byte, currentDir string) (string, error) {
 	return html, nil
 }
 
-// StripRedundantTitle removes a leading <h1>X</h1> from html when its
-// plain-text content equals title. Returns html unchanged when title is
-// empty or no match is found.
+// StripRedundantTitle removes a leading <h1> whose plain-text content equals
+// title, avoiding a duplicate heading when the frontmatter bar already shows
+// it. Returns html unchanged when title is empty or no match is found. HTML
+// entities in the heading are decoded so titles like "A & B" match both
+// `# A & B` (rendered as "A &amp; B") and the plain frontmatter value.
 func StripRedundantTitle(html, title string) string {
 	if title == "" {
 		return html
 	}
-	return stripRedundantTitle(html, title)
-}
-
-// stripRedundantTitle removes a leading <h1> whose plain-text content equals
-// the frontmatter title, avoiding a duplicate heading when the frontmatter
-// bar already shows the title. HTML entities in the heading are decoded so
-// titles like "A & B" match both `# A & B` (rendered as "A &amp; B") and the
-// plain frontmatter value.
-func stripRedundantTitle(html, title string) string {
 	m := leadingH1.FindStringSubmatchIndex(html)
 	if m == nil {
 		return html

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -88,7 +88,7 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 		NotePath:     "",
 		HTML:         template.HTML(`<p class="text-gray-500 dark:text-gray-400 text-center py-8">No note selected.</p>`),
 		ViewHref:     "/",
-		Sidebar: SidebarPartialData{
+		Sidebar: SidebarData{
 			Tags:        tagsCard,
 			InitialJSON: buildInitialJSON(""),
 		},
@@ -180,7 +180,7 @@ func (s *Server) handleView(w http.ResponseWriter, r *http.Request) {
 		HTML:         template.HTML(html),
 		SSEWatch:     viewSSEWatch(reqPath),
 		ViewHref:     "/view/" + viewPath(reqPath),
-		Sidebar: SidebarPartialData{
+		Sidebar: SidebarData{
 			Tags:        tagsCard,
 			InitialJSON: buildInitialJSON(reqPath),
 		},
@@ -285,13 +285,9 @@ func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse the editor env var the way shells treat $EDITOR: the first
-	// token is the binary, the rest are leading arguments (e.g.
-	// `code --wait`, `subl -w`, `nvim -R`). Without this split, exec
-	// looks for a literal binary named `"code --wait"` and 500s. A
-	// whitespace-only value slips past the `== ""` guard above but
-	// yields zero fields, so recheck after Fields to avoid indexing a
-	// nil slice and panicking the handler.
+	// Split the editor value the way shells treat $EDITOR (`code --wait`,
+	// `subl -w`, …). The recheck handles whitespace-only values that pass
+	// the `== ""` guard but yield zero fields.
 	fields := strings.Fields(s.editor)
 	if len(fields) == 0 {
 		http.Error(w, "no editor configured (set NOTESVIEW_EDITOR, VISUAL, or EDITOR)", http.StatusBadRequest)
@@ -313,27 +309,6 @@ func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDir(w http.ResponseWriter, r *http.Request) {
 	dirPath := r.PathValue("path")
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-
-	// Main panel partial: flat listing of this directory.
-	if hxTargetedAt(r, "note-pane") {
-		card, err := s.buildDirIndex(dirPath)
-		if err != nil {
-			s.logger.Warn("dir listing build failed", "dir", dirPath, "err", err)
-			card = &IndexCard{Empty: "Failed to read directory."}
-		}
-		title := dirPath
-		if title == "" {
-			title = "/"
-		}
-		if err := s.templates.renderDirListing(w, DirListingData{Title: title, IndexCard: card}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		return
-	}
-
-	// Full-page load (direct URL visit / reload): render two-pane layout
-	// with directory listing in the main panel.
 	card, err := s.buildDirIndex(dirPath)
 	if err != nil {
 		s.logger.Warn("dir listing build failed", "dir", dirPath, "err", err)
@@ -343,17 +318,29 @@ func (s *Server) handleDir(w http.ResponseWriter, r *http.Request) {
 	if title == "" {
 		title = "/"
 	}
-	tagsCard := s.buildTagsIndex()
+	listing := DirListingData{Title: title, IndexCard: card}
 
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	// Main panel partial: flat listing of this directory.
+	if hxTargetedAt(r, "note-pane") {
+		if err := s.templates.renderDirListing(w, listing); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Full-page load (direct URL visit / reload): render two-pane layout
+	// with directory listing in the main panel.
 	view := ViewData{
 		layoutFields: s.buildLayoutFields(title, ""),
 		HTML:         template.HTML(""),
 		ViewHref:     "/dir/" + viewPath(dirPath),
-		Sidebar: SidebarPartialData{
-			Tags:        tagsCard,
+		Sidebar: SidebarData{
+			Tags:        s.buildTagsIndex(),
 			InitialJSON: buildInitialJSON(dirPath),
 		},
-		DirListing: &DirListingData{Title: title, IndexCard: card},
+		DirListing: &listing,
 	}
 	if err := s.templates.renderView(w, view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -373,7 +360,7 @@ func (s *Server) handleTags(w http.ResponseWriter, r *http.Request) {
 	view := ViewData{
 		layoutFields: s.buildLayoutFields("Tags", ""),
 		ViewHref:     "/tags",
-		Sidebar: SidebarPartialData{
+		Sidebar: SidebarData{
 			Tags:        card,
 			InitialJSON: buildInitialJSON(""),
 		},
@@ -417,7 +404,7 @@ func (s *Server) handleTagNotes(w http.ResponseWriter, r *http.Request) {
 	view := ViewData{
 		layoutFields: s.buildLayoutFields(tag, ""),
 		ViewHref:     "/tags/" + tagPath(tag),
-		Sidebar: SidebarPartialData{
+		Sidebar: SidebarData{
 			Tags:        tagsCard,
 			InitialJSON: buildInitialJSON(""),
 		},

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -285,9 +285,11 @@ func (s *Server) handleEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Split the editor value the way shells treat $EDITOR (`code --wait`,
-	// `subl -w`, …). The recheck handles whitespace-only values that pass
-	// the `== ""` guard but yield zero fields.
+	// Split the $EDITOR-style editor value on Unicode whitespace via
+	// strings.Fields so values like `code --wait` or `subl -w` run as
+	// binary + args. This is not a shell parser — quoting and escaping
+	// are not honored. The recheck handles whitespace-only values that
+	// pass the `== ""` guard but yield zero fields.
 	fields := strings.Fields(s.editor)
 	if len(fields) == 0 {
 		http.Error(w, "no editor configured (set NOTESVIEW_EDITOR, VISUAL, or EDITOR)", http.StatusBadRequest)

--- a/internal/server/templates.go
+++ b/internal/server/templates.go
@@ -54,7 +54,7 @@ type ViewData struct {
 	HTML       template.HTML
 	SSEWatch   string
 	ViewHref   string
-	Sidebar    SidebarPartialData
+	Sidebar    SidebarData
 	DirListing *DirListingData // non-nil when main panel shows a directory listing
 }
 
@@ -72,8 +72,9 @@ type NotePartialData struct {
 	EditHref  string
 }
 
-// SidebarPartialData is the render context for the sidebar tree.
-type SidebarPartialData struct {
+// SidebarData is the render context for the sidebar tree, embedded in
+// every full-page ViewData.
+type SidebarData struct {
 	Tags        *IndexCard  // TAGS section entries
 	InitialJSON template.JS // {"selectedPath": "<path>" | null} — consumed by TreeView
 }

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -92,7 +92,7 @@ func TestRenderView(t *testing.T) {
 		HTML:     template.HTML("<p>Hello world</p>"),
 		SSEWatch: "/events?watch=notes%2Ftest.md",
 		ViewHref: "/view/notes/test.md",
-		Sidebar: SidebarPartialData{
+		Sidebar: SidebarData{
 			Tags: &IndexCard{
 				Entries: nil,
 				Empty:   "No tags found.",


### PR DESCRIPTION
## Summary

This PR refactors the codebase to improve naming clarity and reduce code duplication:

1. **Rename `SidebarPartialData` to `SidebarData`**: The type is embedded in every full-page `ViewData`, not just partials, so the name is now more accurate. Updated all references across handlers and tests.

2. **Consolidate `handleDir` logic**: Moved the directory index building and title computation outside the conditional branches to eliminate duplication. The `DirListingData` is now built once and reused for both HTMX partial and full-page renders.

3. **Simplify `handleEdit` comment**: Shortened the editor parsing comment to be more concise while retaining the essential information about shell-style $EDITOR handling.

4. **Deduplicate UID validation**: Removed the local `isValidUID` function from `noteext.go` and replaced it with a call to `index.IsUID`, eliminating duplicate validation logic.

5. **Consolidate `StripRedundantTitle`**: Merged the internal `stripRedundantTitle` helper into the public `StripRedundantTitle` function, simplifying the API and improving the documentation.

These changes improve code maintainability by reducing duplication and clarifying intent through better naming, with no functional changes to the application behavior.

https://claude.ai/code/session_011tpXpJHQ8jqNJgNVGFjYeH