### PR TITLE
Refactor tests with testify

### DIFF
--- a/cmd/nview/serve_test.go
+++ b/cmd/nview/serve_test.go
@@ -4,73 +4,50 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolvePath_Directory(t *testing.T) {
 	dir := t.TempDir()
 	root, initialFile, err := resolvePath(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want, _ := filepath.Abs(dir)
-	if root != want {
-		t.Errorf("root = %q, want %q", root, want)
-	}
-	if initialFile != "" {
-		t.Errorf("initialFile = %q, want empty", initialFile)
-	}
+	assert.Equal(t, want, root)
+	assert.Empty(t, initialFile)
 }
 
 func TestResolvePath_File(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "note.md")
-	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(file, []byte("hello"), 0o644))
 
 	root, initialFile, err := resolvePath(file)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	wantRoot, _ := filepath.Abs(dir)
-	if root != wantRoot {
-		t.Errorf("root = %q, want %q", root, wantRoot)
-	}
-	if initialFile != "note.md" {
-		t.Errorf("initialFile = %q, want %q", initialFile, "note.md")
-	}
+	assert.Equal(t, wantRoot, root)
+	assert.Equal(t, "note.md", initialFile)
 }
 
 func TestResolvePath_Nonexistent(t *testing.T) {
 	_, _, err := resolvePath("/nonexistent/path/that/does/not/exist")
-	if err == nil {
-		t.Error("expected error for nonexistent path")
-	}
+	assert.Error(t, err)
 }
 
 func TestResolvePath_Symlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target")
-	if err := os.Mkdir(target, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(target, 0o755))
 	link := filepath.Join(dir, "link")
-	if err := os.Symlink(target, link); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Symlink(target, link))
 
 	root, initialFile, err := resolvePath(link)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	// resolvePath uses filepath.Abs, which preserves symlink paths
 	wantRoot, _ := filepath.Abs(link)
-	if root != wantRoot {
-		t.Errorf("root = %q, want %q", root, wantRoot)
-	}
-	if initialFile != "" {
-		t.Errorf("initialFile = %q, want empty", initialFile)
-	}
+	assert.Equal(t, wantRoot, root)
+	assert.Empty(t, initialFile)
 }
 
 func TestExpandTilde(t *testing.T) {
@@ -94,9 +71,7 @@ func TestExpandTilde(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := expandTilde(tt.path)
-			if got != tt.want {
-				t.Errorf("expandTilde(%q) = %q, want %q", tt.path, got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -119,17 +94,12 @@ func TestBrowserCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := browserCommand(tt.goos, tt.url)
 			if tt.wantNil {
-				if cmd != nil {
-					t.Errorf("expected nil command for GOOS=%q", tt.goos)
-				}
+				assert.Nil(t, cmd)
 				return
 			}
-			if cmd == nil {
-				t.Fatalf("expected non-nil command for GOOS=%q", tt.goos)
-			}
-			if filepath.Base(cmd.Path) != tt.wantBin && cmd.Args[0] != tt.wantBin {
-				t.Errorf("expected binary %q, got path %q", tt.wantBin, cmd.Path)
-			}
+			require.NotNil(t, cmd)
+			assert.Truef(t, filepath.Base(cmd.Path) == tt.wantBin || cmd.Args[0] == tt.wantBin,
+				"expected binary %q, got path %q", tt.wantBin, cmd.Path)
 		})
 	}
 }

--- a/cmd/nview/serve_test.go
+++ b/cmd/nview/serve_test.go
@@ -98,8 +98,10 @@ func TestBrowserCommand(t *testing.T) {
 				return
 			}
 			require.NotNil(t, cmd)
-			assert.Truef(t, filepath.Base(cmd.Path) == tt.wantBin || cmd.Args[0] == tt.wantBin,
-				"expected binary %q, got path %q", tt.wantBin, cmd.Path)
+			assert.True(t,
+				filepath.Base(cmd.Path) == tt.wantBin || cmd.Args[0] == tt.wantBin,
+				"want binary %q, got path %q args %v", tt.wantBin, cmd.Path, cmd.Args,
+			)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.7
 require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	github.com/yuin/goldmark v1.8.2
 	github.com/yuin/goldmark-meta v1.1.0
 	golang.org/x/net v0.53.0
@@ -12,7 +13,10 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/sys v0.43.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,20 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-meta v1.1.0 h1:pWw+JLHGZe8Rk0EGsMVssiNb/AaPMHfSRszZeUeiOUc=
@@ -22,3 +28,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -5,28 +5,20 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDefaults(t *testing.T) {
 	ctx := context.Background()
 	logger, closer, err := New(Config{})
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	if closer != nil {
-		t.Errorf("expected nil closer when no file configured")
-	}
-	if logger == nil {
-		t.Fatal("expected non-nil logger")
-	}
-	if !logger.Enabled(ctx, slog.LevelInfo) {
-		t.Errorf("info level should be enabled by default")
-	}
-	if logger.Enabled(ctx, slog.LevelDebug) {
-		t.Errorf("debug level should not be enabled by default")
-	}
+	require.NoError(t, err, "New")
+	assert.Nil(t, closer)
+	require.NotNil(t, logger)
+	assert.True(t, logger.Enabled(ctx, slog.LevelInfo), "info level should be enabled by default")
+	assert.False(t, logger.Enabled(ctx, slog.LevelDebug), "debug level should not be enabled by default")
 }
 
 func TestNewLevels(t *testing.T) {
@@ -41,28 +33,19 @@ func TestNewLevels(t *testing.T) {
 	}
 	for in, want := range cases {
 		logger, _, err := New(Config{Level: in})
-		if err != nil {
-			t.Errorf("New(%q): %v", in, err)
-			continue
-		}
-		if !logger.Enabled(ctx, want) {
-			t.Errorf("level %q: want %v enabled", in, want)
-		}
+		require.NoError(t, err, "New(%q)", in)
+		assert.True(t, logger.Enabled(ctx, want), "level %q: want %v enabled", in, want)
 	}
 }
 
 func TestNewInvalidLevel(t *testing.T) {
 	_, _, err := New(Config{Level: "loud"})
-	if err == nil {
-		t.Fatal("expected error for invalid level")
-	}
+	require.Error(t, err)
 }
 
 func TestNewInvalidFormat(t *testing.T) {
 	_, _, err := New(Config{Format: "yaml"})
-	if err == nil {
-		t.Fatal("expected error for invalid format")
-	}
+	require.Error(t, err)
 }
 
 func TestNewWithFile(t *testing.T) {
@@ -70,12 +53,8 @@ func TestNewWithFile(t *testing.T) {
 	path := filepath.Join(dir, "nested", "nview.log")
 
 	logger, closer, err := New(Config{File: path, Format: "json"})
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	if closer == nil {
-		t.Fatal("expected non-nil closer when file configured")
-	}
+	require.NoError(t, err, "New")
+	require.NotNil(t, closer)
 	defer func() { _ = closer.Close() }()
 
 	logger.Info("hello", "who", "world")
@@ -83,20 +62,15 @@ func TestNewWithFile(t *testing.T) {
 	// The file should have been created alongside any missing parent dirs
 	// and should contain the JSON-encoded record.
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read log file: %v", err)
-	}
+	require.NoError(t, err, "read log file")
 	s := string(data)
-	if !strings.Contains(s, `"msg":"hello"`) || !strings.Contains(s, `"who":"world"`) {
-		t.Errorf("log file content = %q, want JSON record with msg/who fields", s)
-	}
+	assert.Contains(t, s, `"msg":"hello"`)
+	assert.Contains(t, s, `"who":"world"`)
 }
 
 func TestDiscardLogger(t *testing.T) {
 	logger := Discard()
-	if logger == nil {
-		t.Fatal("expected non-nil logger")
-	}
+	require.NotNil(t, logger)
 	// Error is the lowest level we allow through, but output goes to io.Discard,
 	// so this should not panic or produce visible output.
 	logger.Error("dropped")

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -23,18 +23,23 @@ func TestNewDefaults(t *testing.T) {
 
 func TestNewLevels(t *testing.T) {
 	ctx := context.Background()
-	cases := map[string]slog.Level{
-		"debug":   slog.LevelDebug,
-		"info":    slog.LevelInfo,
-		"warn":    slog.LevelWarn,
-		"warning": slog.LevelWarn,
-		"error":   slog.LevelError,
-		"DEBUG":   slog.LevelDebug,
+	cases := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"DEBUG", slog.LevelDebug},
 	}
-	for in, want := range cases {
-		logger, _, err := New(Config{Level: in})
-		require.NoError(t, err, "New(%q)", in)
-		assert.True(t, logger.Enabled(ctx, want), "level %q: want %v enabled", in, want)
+	for _, tt := range cases {
+		t.Run(tt.in, func(t *testing.T) {
+			logger, _, err := New(Config{Level: tt.in})
+			require.NoError(t, err, "New(%q)", tt.in)
+			assert.True(t, logger.Enabled(ctx, tt.want), "level %q: want %v enabled", tt.in, tt.want)
+		})
 	}
 }
 

--- a/internal/renderer/highlighting_test.go
+++ b/internal/renderer/highlighting_test.go
@@ -1,35 +1,27 @@
 package renderer
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRenderFencedCodeBlockEmitsLanguageClass(t *testing.T) {
 	r := NewRenderer(nil)
 	src := []byte("```go\nfunc foo() {}\n```\n")
 	out, err := r.Render(src, "")
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
-	if !strings.Contains(out, `<code class="language-go">`) {
-		t.Errorf("expected output to contain <code class=\"language-go\">, got:\n%s", out)
-	}
-	if strings.Contains(out, "style=") {
-		t.Errorf("expected output to contain no inline style attributes (chroma fingerprint), got:\n%s", out)
-	}
+	require.NoError(t, err, "Render")
+	assert.Contains(t, out, `<code class="language-go">`)
+	assert.NotContains(t, out, "style=", "expected output to contain no inline style attributes (chroma fingerprint)")
 }
 
 func TestRenderFencedCodeBlockWithoutLanguage(t *testing.T) {
 	r := NewRenderer(nil)
 	src := []byte("```\nplain text\n```\n")
 	out, err := r.Render(src, "")
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
-	if !strings.Contains(out, "<pre><code>") {
-		t.Errorf("expected output to contain <pre><code>, got:\n%s", out)
-	}
+	require.NoError(t, err, "Render")
+	assert.Contains(t, out, "<pre><code>")
 }
 
 // TestRenderEscapesRawHTML locks in the goldmark.WithUnsafe() absence:
@@ -38,10 +30,6 @@ func TestRenderEscapesRawHTML(t *testing.T) {
 	r := NewRenderer(nil)
 	src := []byte("Hello\n\n<script>alert('xss')</script>\n")
 	out, err := r.Render(src, "")
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
-	if strings.Contains(out, "<script>") {
-		t.Errorf("expected raw <script> to be escaped, got:\n%s", out)
-	}
+	require.NoError(t, err, "Render")
+	assert.NotContains(t, out, "<script>", "expected raw <script> to be escaped")
 }

--- a/internal/renderer/renderer_test.go
+++ b/internal/renderer/renderer_test.go
@@ -1,22 +1,18 @@
 package renderer
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRenderBasicMarkdown(t *testing.T) {
 	r := NewRenderer(nil)
 	html, err := r.Render([]byte("# Hello\n\nSome text."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if !strings.Contains(html, "Hello") {
-		t.Errorf("expected HTML to contain heading, got: %s", html)
-	}
-	if !strings.Contains(html, "Some text") {
-		t.Errorf("expected HTML to contain body, got: %s", html)
-	}
+	require.NoError(t, err, "Render failed")
+	assert.Contains(t, html, "Hello")
+	assert.Contains(t, html, "Some text")
 }
 
 // TestRenderSkipsFrontmatter pins that goldmark-meta still consumes the
@@ -26,41 +22,25 @@ func TestRenderBasicMarkdown(t *testing.T) {
 func TestRenderSkipsFrontmatter(t *testing.T) {
 	r := NewRenderer(nil)
 	html, err := r.Render([]byte("---\ntitle: My Note\n---\n# Hello\n\nBody."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if strings.Contains(html, "title: My Note") {
-		t.Errorf("frontmatter YAML leaked into HTML: %s", html)
-	}
-	if !strings.Contains(html, "Hello") {
-		t.Errorf("expected body content in HTML: %s", html)
-	}
+	require.NoError(t, err, "Render failed")
+	assert.NotContains(t, html, "title: My Note", "frontmatter YAML leaked into HTML")
+	assert.Contains(t, html, "Hello")
 }
 
 func TestRenderEmptyDocument(t *testing.T) {
 	r := NewRenderer(nil)
 	html, err := r.Render([]byte(""), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-	if html != "" {
-		t.Errorf("expected empty HTML for empty input, got %q", html)
-	}
+	require.NoError(t, err, "Render failed")
+	assert.Empty(t, html)
 }
 
 func TestStripRedundantTitleExact(t *testing.T) {
 	r := NewRenderer(nil)
 	html, err := r.Render([]byte("# Hello World\n\nBody text."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
+	require.NoError(t, err, "Render failed")
 	html = StripRedundantTitle(html, "Hello World")
-	if strings.Contains(html, "<h1") {
-		t.Errorf("redundant <h1> should be stripped, got: %s", html)
-	}
-	if !strings.Contains(html, "Body text") {
-		t.Errorf("body text should be preserved, got: %s", html)
-	}
+	assert.NotContains(t, html, "<h1", "redundant <h1> should be stripped")
+	assert.Contains(t, html, "Body text")
 }
 
 func TestStripRedundantTitleHTMLEntities(t *testing.T) {
@@ -68,13 +48,9 @@ func TestStripRedundantTitleHTMLEntities(t *testing.T) {
 	// Goldmark renders "A & B" in a heading as "A &amp; B".
 	// StripRedundantTitle should decode entities before comparing.
 	html, err := r.Render([]byte("# A & B\n\nBody."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
+	require.NoError(t, err, "Render failed")
 	html = StripRedundantTitle(html, "A & B")
-	if strings.Contains(html, "<h1") {
-		t.Errorf("h1 with HTML entities should be stripped when matching title, got: %s", html)
-	}
+	assert.NotContains(t, html, "<h1", "h1 with HTML entities should be stripped when matching title")
 }
 
 func TestStripRedundantTitleInlineMarkup(t *testing.T) {
@@ -82,51 +58,33 @@ func TestStripRedundantTitleInlineMarkup(t *testing.T) {
 	// "# **Bold** title" renders as <h1><strong>Bold</strong> title</h1>.
 	// After stripping inner tags, the plain text is "Bold title".
 	html, err := r.Render([]byte("# **Bold** title\n\nBody."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
+	require.NoError(t, err, "Render failed")
 	html = StripRedundantTitle(html, "Bold title")
-	if strings.Contains(html, "<h1") {
-		t.Errorf("h1 with inline markup should be stripped when plain text matches title, got: %s", html)
-	}
+	assert.NotContains(t, html, "<h1", "h1 with inline markup should be stripped when plain text matches title")
 }
 
 func TestStripRedundantTitleMismatch(t *testing.T) {
 	r := NewRenderer(nil)
 	html, err := r.Render([]byte("# Different Heading\n\nBody."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
+	require.NoError(t, err, "Render failed")
 	html = StripRedundantTitle(html, "Actual Title")
-	if !strings.Contains(html, "<h1") {
-		t.Errorf("non-matching h1 should be preserved, got: %s", html)
-	}
-	if !strings.Contains(html, "Different Heading") {
-		t.Errorf("heading text should be preserved, got: %s", html)
-	}
+	assert.Contains(t, html, "<h1", "non-matching h1 should be preserved")
+	assert.Contains(t, html, "Different Heading")
 }
 
 func TestStripRedundantTitleLeadingWhitespace(t *testing.T) {
 	// The leadingH1 regex tolerates leading whitespace before <h1>.
 	got := StripRedundantTitle("  \n<h1>Hello</h1>\n<p>Body</p>", "Hello")
-	if strings.Contains(got, "<h1") {
-		t.Errorf("leading whitespace before h1 should still match, got: %s", got)
-	}
-	if !strings.Contains(got, "<p>Body</p>") {
-		t.Errorf("body should be preserved, got: %s", got)
-	}
+	assert.NotContains(t, got, "<h1", "leading whitespace before h1 should still match")
+	assert.Contains(t, got, "<p>Body</p>")
 }
 
 func TestStripRedundantTitleNoH1(t *testing.T) {
 	r := NewRenderer(nil)
 	html, err := r.Render([]byte("## Subtitle\n\nBody."), "")
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
+	require.NoError(t, err, "Render failed")
 	html = StripRedundantTitle(html, "My Title")
-	if !strings.Contains(html, "Subtitle") {
-		t.Errorf("h2 should be preserved, got: %s", html)
-	}
+	assert.Contains(t, html, "Subtitle")
 }
 
 func TestStripRedundantTitleEmptyTitle(t *testing.T) {
@@ -134,7 +92,5 @@ func TestStripRedundantTitleEmptyTitle(t *testing.T) {
 	// <h1> — otherwise a misconfigured caller could accidentally strip
 	// legitimate headings.
 	html := StripRedundantTitle("<h1>Keep This</h1><p>Body</p>", "")
-	if !strings.Contains(html, "<h1") {
-		t.Errorf("empty title should leave h1 intact, got: %s", html)
-	}
+	assert.Contains(t, html, "<h1", "empty title should leave h1 intact")
 }

--- a/internal/renderer/tasks_test.go
+++ b/internal/renderer/tasks_test.go
@@ -1,8 +1,10 @@
 package renderer
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTaskSyntax(t *testing.T) {
@@ -37,13 +39,9 @@ func TestTaskSyntax(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			html, err := r.Render([]byte(tt.input), "")
-			if err != nil {
-				t.Fatalf("Render failed: %v", err)
-			}
+			require.NoError(t, err, "Render failed")
 			for _, want := range tt.contains {
-				if !strings.Contains(html, want) {
-					t.Errorf("output missing %q\ngot: %s", want, html)
-				}
+				assert.Contains(t, html, want)
 			}
 		})
 	}

--- a/internal/server/pathutil_test.go
+++ b/internal/server/pathutil_test.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSafePath(t *testing.T) {
@@ -25,18 +28,11 @@ func TestSafePath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := SafePath(root, tt.reqPath)
 			if tt.wantErr {
-				if err == nil {
-					t.Errorf("expected error for %q, got %q", tt.reqPath, got)
-				}
+				assert.Error(t, err, "expected error for %q, got %q", tt.reqPath, got)
 				return
 			}
-			if err != nil {
-				t.Errorf("unexpected error for %q: %v", tt.reqPath, err)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("SafePath(%q, %q) = %q, want %q", root, tt.reqPath, got, tt.want)
-			}
+			require.NoError(t, err, "SafePath(%q, %q)", root, tt.reqPath)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/server/pathutil_test.go
+++ b/internal/server/pathutil_test.go
@@ -32,7 +32,7 @@ func TestSafePath(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "SafePath(%q, %q)", root, tt.reqPath)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, got, "SafePath(%q, %q)", root, tt.reqPath)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add testify for test assertions and requirements.
- Simplify repetitive test boilerplate in command, logging, renderer, and server path tests.
- Keep existing test coverage and behavior unchanged.

## Testing

- go test ./...