### PR TITLE
Switch notes import path from notesctl to notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Changed
 
+- Re-point the `notes` library dependency from `github.com/dreikanter/notesctl` to `github.com/dreikanter/notes` to follow the upstream rename. No behavior change ([#116]).
 - Replace fsnotify-based watcher loop with notesctl's `Store.Watch`, switch the index to incremental `Apply` updates, and gate SSE delivery on a per-view scope (`scope=note&id=X` for single-note views, `scope=list` for index pages). Adds `POST /api/index/refresh` plus a topbar refresh button and visibilitychange-driven reconcile so missed events are recovered on tab focus. ([#110])
 
+[#116]: https://github.com/dreikanter/nview/pull/116
 [#110]: https://github.com/dreikanter/nview/issues/110
 
 ## [0.2.0] - 2026-04-26

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dreikanter/nview
 go 1.26.2
 
 require (
-	github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1
+	github.com/dreikanter/notes v0.3.30
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/yuin/goldmark v1.8.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dreikanter/nview
 go 1.26.2
 
 require (
-	github.com/dreikanter/notesctl v0.3.26
+	github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/yuin/goldmark v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1 h1:XaDHo6WjcQxaUctYLVxgJXpFyDeuOuFEgO7GH6uIEDQ=
-github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1/go.mod h1:FzuOTsqeA9XIShsPyNFxUOcchyjcLccjWw9QhDKW4no=
+github.com/dreikanter/notes v0.3.30 h1:RWJc78murQMbWf8sc3bqXQB+NHLe7+3n5cs0/XCOZRU=
+github.com/dreikanter/notes v0.3.30/go.mod h1:FzuOTsqeA9XIShsPyNFxUOcchyjcLccjWw9QhDKW4no=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dreikanter/notesctl v0.3.26 h1:caFobS7sO310iDurRUw8wy2hvR5jiSWFZKkt0mTqm+E=
-github.com/dreikanter/notesctl v0.3.26/go.mod h1:IWa7NgGlbmEL9TXAYo8OG6o34PF24HZbS/hVJzOZwc8=
+github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1 h1:XaDHo6WjcQxaUctYLVxgJXpFyDeuOuFEgO7GH6uIEDQ=
+github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1/go.mod h1:FzuOTsqeA9XIShsPyNFxUOcchyjcLccjWw9QhDKW4no=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/index/note_index.go
+++ b/internal/index/note_index.go
@@ -11,13 +11,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 
 	"github.com/dreikanter/nview/internal/logging"
 )
 
 // NoteEntry is the per-note record held in the index. It is a thin
-// projection of note.Entry.Meta; filesystem paths are notesctl-internal.
+// projection of note.Entry.Meta; filesystem paths are notes-internal.
 type NoteEntry struct {
 	ID          int
 	RelPath     string
@@ -115,7 +115,7 @@ func projectEntry(e note.Entry) NoteEntry {
 }
 
 // entryRelPath reconstructs the forward-slash relative path for e using the
-// same YYYY/MM/YYYYMMDD_ID[_slug][.type].md layout that notesctl writes.
+// same YYYY/MM/YYYYMMDD_ID[_slug][.type].md layout that notes writes.
 func entryRelPath(e note.Entry) string {
 	date := e.Meta.CreatedAt.Format(note.DateFormat)
 	filename := note.Filename(date, e.ID, e.Meta.Slug, e.Meta.Type)

--- a/internal/index/note_index_test.go
+++ b/internal/index/note_index_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 )
 
 // day returns a UTC midnight time for the given year, month, day — keeps

--- a/internal/renderer/noteext_test.go
+++ b/internal/renderer/noteext_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 
 	"github.com/dreikanter/nview/internal/index"
 )

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 
 	"github.com/dreikanter/nview/internal/index"
 	"github.com/dreikanter/nview/internal/logging"

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 
 	"github.com/dreikanter/nview/internal/index"
 )

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 
 	"github.com/dreikanter/nview/internal/index"
 	"github.com/dreikanter/nview/internal/logging"


### PR DESCRIPTION
## Summary

- Re-point the `notes` library dependency from `github.com/dreikanter/notesctl` to `github.com/dreikanter/notes` to follow the upstream rename
- Pinned to a pseudo-version of the rename branch ([dreikanter/notes#270](https://github.com/dreikanter/notes/pull/270)); will be retagged once that PR is merged and a new release is cut

## References

- Depends on dreikanter/notes#270