### PR TITLE
Adopt Unreleased-first release workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 -
 
+## Checklist
+
+- [ ] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only
+
 <!-- Remove the References section below if there are no related issues, PRs, or resources. -->
 ## References
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,18 +12,44 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
-      - name: Bump patch version and push tag
+      - name: Tag from CHANGELOG when version changed
         run: |
-          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          if [ -z "$LATEST" ]; then
-            NEXT="v0.1.0"
-          else
-            PATCH=$(echo "$LATEST" | cut -d. -f3)
-            NEXT="v0.1.$((PATCH + 1))"
+          set -euo pipefail
+
+          version_from_ref() {
+            git show "$1:CHANGELOG.md" |
+              grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' |
+              tr -d '[]' |
+              awk '{print $2}'
+          }
+
+          VERSION=$(version_from_ref HEAD || true)
+          PREV_REF="${{ github.event.pull_request.base.sha }}"
+          if ! git rev-parse -q --verify "$PREV_REF^{commit}" >/dev/null; then
+            PREV_REF="HEAD^1"
           fi
+          PREV_VERSION=$(version_from_ref "$PREV_REF" || true)
+
+          if [ -z "$VERSION" ]; then
+            echo "No version heading found in CHANGELOG.md" >&2
+            exit 1
+          fi
+
+          if [ "$VERSION" = "$PREV_VERSION" ]; then
+            echo "Topmost CHANGELOG version unchanged ($VERSION); skipping"
+            exit 0
+          fi
+
+          NEXT="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$NEXT" >/dev/null; then
+            echo "Tag $NEXT already exists; skipping"
+            exit 0
+          fi
+
           git tag "$NEXT"
           git push origin "$NEXT"
           echo "Tagged $NEXT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release.
 - Re-point the `notes` library dependency from `github.com/dreikanter/notesctl` to `github.com/dreikanter/notes` to follow the upstream rename. No behavior change ([#116]).
 - Replace fsnotify-based watcher loop with notesctl's `Store.Watch`, switch the index to incremental `Apply` updates, and gate SSE delivery on a per-view scope (`scope=note&id=X` for single-note views, `scope=list` for index pages). Adds `POST /api/index/refresh` plus a topbar refresh button and visibilitychange-driven reconcile so missed events are recovered on tab focus. ([#110])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Changed
 
-- Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release.
+- Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#117]).
 - Re-point the `notes` library dependency from `github.com/dreikanter/notesctl` to `github.com/dreikanter/notes` to follow the upstream rename. No behavior change ([#116]).
 - Replace fsnotify-based watcher loop with notesctl's `Store.Watch`, switch the index to incremental `Apply` updates, and gate SSE delivery on a per-view scope (`scope=note&id=X` for single-note views, `scope=list` for index pages). Adds `POST /api/index/refresh` plus a topbar refresh button and visibilitychange-driven reconcile so missed events are recovered on tab focus. ([#110])
 
+[#117]: https://github.com/dreikanter/nview/pull/117
 [#116]: https://github.com/dreikanter/nview/pull/116
 [#110]: https://github.com/dreikanter/nview/issues/110
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,40 @@
 # CLAUDE.md
 
+## Versioning
+
+Version is set at build time via git tags and `-ldflags`. The `Version` var in
+`cmd/nview/main.go` defaults to `"dev"` and is overridden by `make install` /
+`make build` using `git describe --tags`.
+
+Releases are created by dedicated release PRs. Regular PRs do not bump the
+version number. On release PR merge, GitHub Actions (`.github/workflows/tag.yml`)
+reads the topmost numeric `## [X.Y.Z]` heading from `CHANGELOG.md` and pushes
+`vX.Y.Z` as a git tag when that heading changed.
+
+## Changelog
+
+Use `CHANGELOG.md` as the source of truth for release notes.
+
+Rules:
+- Keep an `## [Unreleased]` section at the top.
+- PRs with user-visible changes should add an entry under `Unreleased`.
+- Internal-only PRs may skip the changelog.
+- Do not create a new version heading in regular PRs.
+- A release PR converts `Unreleased` into `## [X.Y.Z] - YYYY-MM-DD` and adds a
+  fresh empty `## [Unreleased]` section above it.
+- One release may include multiple PRs.
+- Reference PR numbers (`[#N]`) in changelog bullets when known and add links at
+  the bottom.
+- It is acceptable to open a PR with an `Unreleased` entry that does not yet
+  include its PR number; add the PR reference in a follow-up commit after GitHub
+  assigns the number when the entry should reference the PR.
+
+Version bump guidance:
+- Patch: fixes, docs, small behavior improvements, and internal changes worth
+  releasing.
+- Minor: new commands, flags, public APIs, or meaningful new behavior.
+- Major: breaking CLI, config, schema, or Go API changes.
+
 ## Pull Requests
 
 - Keep PR descriptions lean. Summarize the change in a few bullets; do not pad with implementation details that the diff already shows.


### PR DESCRIPTION
## Summary

- Add this workflow change to the existing `Unreleased` changelog section
- Document the release-PR versioning workflow in `CLAUDE.md`
- Update auto-tagging to tag only when the topmost numeric changelog version changes
- Add a changelog checklist item to the PR template

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only
