### PR TITLE
Drop redundant 'version' word from --version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `nview --version` no longer prints a redundant `version v...`; the output is now `nview vX.Y.Z`.
+
 ### Changed
 
 - Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#117]).

--- a/cmd/nview/main.go
+++ b/cmd/nview/main.go
@@ -24,6 +24,7 @@ func init() {
 		}
 	}
 	rootCmd.Version = Version
+	rootCmd.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 }
 
 func main() {


### PR DESCRIPTION
## Summary

- `nview --version` previously printed `nview version v...`, with a redundant `version v` because git tags use the `vX.Y.Z` form and Cobra's default version template adds its own `version` word.
- Override Cobra's version template to `{{.Name}} {{.Version}}`, so output is now `nview v...`.
- Keeps `Version` matching the canonical git tag / Go module version (also returned by `debug.ReadBuildInfo`), so the displayed string is consistent across local builds and `go install ...@vX.Y.Z` builds.

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only